### PR TITLE
Add basic ExchangeMailboxUser model which deals with #171

### DIFF
--- a/src/Models/ActiveDirectory/ExchangeMailboxUser.php
+++ b/src/Models/ActiveDirectory/ExchangeMailboxUser.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace LdapRecord\Models\ActiveDirectory;
+
+class ExchangeMailboxUser extends User
+{
+    protected static function boot()
+    {
+        parent::boot();
+
+        self::$objectClasses['msExchMailboxGuid'] = '*';
+    }
+}

--- a/src/Models/ActiveDirectory/ExchangeMailboxUser.php
+++ b/src/Models/ActiveDirectory/ExchangeMailboxUser.php
@@ -2,12 +2,14 @@
 
 namespace LdapRecord\Models\ActiveDirectory;
 
+use LdapRecord\Models\ActiveDirectory\Scopes\IncludeMailboxUsers;
+
 class ExchangeMailboxUser extends User
 {
     protected static function boot()
     {
         parent::boot();
 
-        self::$objectClasses['msExchMailboxGuid'] = '*';
+        self::addGlobalScope(new IncludeMailboxUsers());
     }
 }

--- a/src/Models/ActiveDirectory/Scopes/IncludeMailboxUsers.php
+++ b/src/Models/ActiveDirectory/Scopes/IncludeMailboxUsers.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LdapRecord\Models\ActiveDirectory\Scopes;
+
+use LdapRecord\Models\Model;
+use LdapRecord\Models\Scope;
+use LdapRecord\Query\Model\Builder;
+
+class IncludeMailboxUsers implements Scope
+{
+    /**
+     * Adds a clause to include users with an Exchange mailbox
+     *
+     * @param Builder $query
+     * @param Model   $model
+     *
+     * @return void
+     */
+    public function apply(Builder $query, Model $model)
+    {
+        $query->whereHas('msExchMailboxGuid');
+    }
+}

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -415,7 +415,6 @@ abstract class Model implements ArrayAccess, JsonSerializable
         foreach (static::$objectClasses as $key => $objectClass) {
             $attribute = is_string($key) ? $key : 'objectclass';
 
-            echo "{$attribute} = {$objectClass}\n";
             $query->where($attribute, $objectClass);
         }
     }

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -412,8 +412,11 @@ abstract class Model implements ArrayAccess, JsonSerializable
      */
     public function applyObjectClassScopes(Builder $query)
     {
-        foreach (static::$objectClasses as $objectClass) {
-            $query->where('objectclass', '=', $objectClass);
+        foreach (static::$objectClasses as $key => $objectClass) {
+            $attribute = is_string($key) ? $key : 'objectclass';
+
+            echo "{$attribute} = {$objectClass}\n";
+            $query->where($attribute, $objectClass);
         }
     }
 

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -412,10 +412,8 @@ abstract class Model implements ArrayAccess, JsonSerializable
      */
     public function applyObjectClassScopes(Builder $query)
     {
-        foreach (static::$objectClasses as $key => $objectClass) {
-            $attribute = is_string($key) ? $key : 'objectclass';
-
-            $query->where($attribute, $objectClass);
+        foreach (static::$objectClasses as $objectClass) {
+            $query->where('objectclass', '=', $objectClass);
         }
     }
 


### PR DESCRIPTION
I had to change the underlying `applyObjectClassScopes` to account for star queries. I'm still tinkering with different objects, but this worked with my organization to retrieve "mailbox users" aka users with a mailbox guid. Let me know what you think. 

I'm working on ExchangeServer and ExchangeDatabase models now as well, but the objectclass that ldaptools references has aren't returning results for me. I _do_ retrieve results for our servers under the `Computer` model, but can't pinpoint anything that distinguishes it as an "Exchange Server" that could be universally true. Google is failing me also.