### PR TITLE
Fixed auth attempt bind as user

### DIFF
--- a/src/Auth/Guard.php
+++ b/src/Auth/Guard.php
@@ -82,7 +82,7 @@ class Guard
             $authenticated = false;
         }
 
-        if (! $bindAsUser) {
+        if ($bindAsUser) {
             $this->bindAsConfiguredUser();
         }
 


### PR DESCRIPTION
Auth->attempt accept parameter `$bindAsUser` but binds the user if parameter was `false`. As the wording says it must bind the user if the paramter is `true`.