### PR TITLE
Resolved an issue with salted password handling and add crypt() as ha…

### DIFF
--- a/src/Models/ActiveDirectory/User.php
+++ b/src/Models/ActiveDirectory/User.php
@@ -16,6 +16,20 @@ class User extends Entry implements Authenticatable
     use CanAuthenticate;
 
     /**
+     * The password's attribute name.
+     *
+     * @var string
+     */
+    protected $passwordAttribute = 'unicodepwd';
+
+    /**
+     * The password's hash method.
+     *
+     * @var string
+     */
+    protected $passwordHashMethod = 'encode';
+
+    /**
      * The object classes of the LDAP model.
      *
      * @var array

--- a/src/Models/Attributes/Password.php
+++ b/src/Models/Attributes/Password.php
@@ -2,11 +2,16 @@
 
 namespace LdapRecord\Models\Attributes;
 
+use ReflectionMethod;
 use InvalidArgumentException;
 use LdapRecord\LdapRecordException;
 
 class Password
 {
+    const CRYPT_SALT_TYPE_MD5 = 1;
+    const CRYPT_SALT_TYPE_SHA256 = 5;
+    const CRYPT_SALT_TYPE_SHA512 = 6;
+
     /**
      * Make an encoded password for transmission over LDAP.
      *
@@ -22,66 +27,66 @@ class Password
     /**
      * Make a salted md5 password.
      *
-     * @param string $password
+     * @param string      $password
+     * @param null|string $salt
      *
      * @return string
      */
     public static function smd5($password, $salt = null)
     {
-        if(!$salt) $salt = random_bytes(4);
-        return '{SMD5}'.static::makeHash($password, 'md5', null, $salt);
-    }
-
-    /**
-     * Make a salted SSHA512 password.
-     *
-     * @param string $password
-     *
-     * @return string
-     */
-    public static function ssha512($password, $salt = null)
-    {
-        if(!$salt) $salt = random_bytes(4);
-        return '{SSHA512}'.static::makeHash($password, 'hash', 'sha512', $salt);
+        return '{SMD5}'.static::makeHash($password, 'md5', null, $salt ?? random_bytes(4));
     }
 
     /**
      * Make a salted SHA password.
      *
-     * @param string $password
+     * @param string      $password
+     * @param null|string $salt
      *
      * @return string
      */
     public static function ssha($password, $salt = null)
     {
-        if(!$salt) $salt = random_bytes(4);
-        return '{SSHA}'.static::makeHash($password, 'sha1', null, $salt);
+        return '{SSHA}'.static::makeHash($password, 'sha1', null, $salt ?? random_bytes(4));
     }
 
     /**
      * Make a salted SSHA256 password.
      *
-     * @param string $password
+     * @param string      $password
+     * @param null|string $salt
      *
      * @return string
      */
     public static function ssha256($password, $salt = null)
     {
-        if(!$salt) $salt = random_bytes(4);
-        return '{SSHA256}'.static::makeHash($password, 'hash', 'sha256', $salt);
+        return '{SSHA256}'.static::makeHash($password, 'hash', 'sha256', $salt ?? random_bytes(4));
     }
 
     /**
      * Make a salted SSHA384 password.
      *
-     * @param string $password
+     * @param string      $password
+     * @param null|string $salt
      *
      * @return string
      */
     public static function ssha384($password, $salt = null)
     {
-        if(!$salt) $salt = random_bytes(4);
-        return '{SSHA384}'.static::makeHash($password, 'hash', 'sha384', $salt);
+        return '{SSHA384}'.static::makeHash($password, 'hash', 'sha384', $salt ?? random_bytes(4));
+    }
+
+    /**
+     * Make a salted SSHA512 password.
+     *
+     * @param string      $password
+     * @param null|string $salt
+     *
+     * @return string
+     */
+    public static function ssha512($password, $salt = null)
+    {
+        return '{SSHA512}'.static::makeHash($password, 'hash', 'sha512', $salt ?? random_bytes(4));
     }
 
     /**
@@ -145,54 +150,51 @@ class Password
     }
     
     /**
-     * Crypt password with SHA512
+     * Crypt password with an MD5 salt.
      *
-     * @param string $password Password to encrypt
-     * @param string $salt Salt
+     * @param string $password
+     * @param string $salt
      * 
      * @return string
      */
-    public static function md5crypt($password, $salt = null)  : string
+    public static function md5Crypt($password, $salt = null)
     {
-        if(!$salt) $salt = self::makeCryptSalt(1);
-        return '{CRYPT}' . crypt($password, $salt);
+        return '{CRYPT}'.static::makeCrypt($password, static::CRYPT_SALT_TYPE_MD5, $salt);
     }
 
     /**
-     * Crypt password with SHA512
+     * Crypt password with a SHA256 salt.
      *
-     * @param string $password Password to encrypt
-     * @param string $salt Salt
+     * @param string $password
+     * @param string $salt
      * 
      * @return string
      */
-    public static function sha256crypt($password, $salt = null) : string
+    public static function sha256Crypt($password, $salt = null)
     {
-        if(!$salt) $salt = self::makeCryptSalt(5);
-        return '{CRYPT}' . crypt($password, $salt);
+        return '{CRYPT}'.static::makeCrypt($password, static::CRYPT_SALT_TYPE_SHA256, $salt);
     }
 
     /**
-     * Crypt password with SHA512
+     * Crypt a password with a SHA512 salt.
      *
-     * @param string $password Password to encrypt
-     * @param string $salt Salt
+     * @param string $password
+     * @param string $salt
      * 
      * @return string
      */
-    public static function sha512crypt($password, $salt = null) : string
+    public static function sha512Crypt($password, $salt = null)
     {
-        if(!$salt) $salt = self::makeCryptSalt(6);
-        return '{CRYPT}' . crypt($password, $salt);
+        return '{CRYPT}'.static::makeCrypt($password, static::CRYPT_SALT_TYPE_SHA512, $salt);
     }
 
     /**
      * Make a new password hash.
      *
-     * @param string $password The password to make a hash of
-     * @param string $method The hash function to use
-     * @param string|null $algo The algorithm to use for hashing
-     * @param string|null $salt Salt for encrytion
+     * @param string      $password The password to make a hash of.
+     * @param string      $method The hash function to use.
+     * @param string|null $algo The algorithm to use for hashing.
+     * @param string|null $salt The salt to append onto the hash.
      *
      * @return string
      */
@@ -204,73 +206,128 @@ class Password
     }
 
     /**
-     * Create special salt for crypt() method
+     * Make a hashed password.
      *
-     * @param integer $algo Crypt alogorythem
-     * 
-     * @return string Returns salt with prefix
+     * @param string      $password
+     * @param int         $type
+     * @param null|string $salt
+     *
+     * @return string
      */
-    private static function makeCryptSalt(string $type) : string
+    protected static function makeCrypt($password, $type, $salt = null)
     {
-        switch($type){
-            case "1":
-                $salt = '$1$';
-                $len = 12;
-            break;
-            case "5": 
-                $salt = '$5$';
-                $len = 16;
-            break;
-            case "6":
-                $salt = '$6$';
-                $len = 16;
-            break;
+        return crypt($password, $salt ?? static::makeCryptSalt($type));
+    }
+
+    /**
+     * Make a salt for the crypt() method using the given type.
+     *
+     * @param int $type
+     * 
+     * @return string
+     */
+    protected static function makeCryptSalt($type)
+    {
+        [$prefix, $length] = static::makeCryptPrefixAndLength($type);
+
+        $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+        while(strlen($prefix) <  $length) {
+            $prefix .= substr($chars, random_int(0, strlen($chars) - 1), 1);
+        }
+
+        return $prefix;
+    }
+
+    /**
+     * Determine the crypt prefix and length.
+     *
+     * @param int $type
+     *
+     * @return array
+     *
+     * @throws InvalidArgumentException
+     */
+    protected static function makeCryptPrefixAndLength($type)
+    {
+        switch($type) {
+            case static::CRYPT_SALT_TYPE_MD5:
+                return ['$1$', 12];
+            case static::CRYPT_SALT_TYPE_SHA256:
+                return ['$5$', 16];
+            case static::CRYPT_SALT_TYPE_SHA512:
+                return ['$6$', 16];
             default:
                 throw new InvalidArgumentException("Invalid crypt type");
         }
-
-        $str = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-        while(strlen($salt) <  $len) {
-            $salt .= substr($str, random_int(0, strlen($str) - 1), 1);
-        }
-
-        return $salt;
     }
 
     /**
-     * Get salt from encrypted password
+     * Attempt to retrieve the password hash method used for the password.
      *
-     * @return null|string return string if password is saled
+     * @param string $password
+     *
+     * @return string|void
+     */
+    public static function getHashMethod($password)
+    {
+        if (! preg_match( '/^\{(\w+)\}/', $password, $matches)) {
+            return;
+        }
+
+        return $matches[1];
+    }
+
+    public static function getHashMethodAndAlgo($password)
+    {
+        if (! preg_match('/^\{(\w+)\}\$([0-9a-z]{1})\$/', $password, $matches)) {
+            return;
+        }
+
+        return [$matches[1], $matches[2]];
+    }
+
+    /**
+     * Attempt to retrieve a salt from the encrypted password.
+     *
+     * @return string
+     *
+     * @throws LdapRecordException
      */
     public static function getSalt($encryptedPassword)
     {
-        // crypt() methods
-        if(preg_match('/^\{(\w+)\}(\$.*\$).*$/', $encryptedPassword, $mc)){
-            return $mc[2];
+        // crypt() methods.
+        if (preg_match('/^\{(\w+)\}(\$.*\$).*$/', $encryptedPassword, $matches)){
+            return $matches[2];
         }
 
-        // All other methods
-        if (preg_match('/{([^}]+)}(.*)/', $encryptedPassword, $mc)) {
-            return substr(base64_decode($mc[2]), -4);
+        // All other methods.
+        if (preg_match('/{([^}]+)}(.*)/', $encryptedPassword, $matches)) {
+            return substr(base64_decode($matches[2]), -4);
         }
 
-        throw new LdapRecordException("Could not extract salt from encrypted password");
+        throw new LdapRecordException("Could not extract salt from encrypted password.");
     }
 
     /**
-     * Method is using salt for encryption.
+     * Determine if the hash method requires a salt to be given.
      *
-     * @param string $method Method name
+     * @param string $method
      * 
      * @return boolean
+     *
+     * @throws \ReflectionException
      */
-    public static function isSalted($method) : bool
+    public static function hashMethodRequiresSalt($method) : bool
     {
-        foreach((new \ReflectionMethod(self::class, $method))->getParameters() as $parameter){
-            if ($parameter->name == "salt") {
+        $parameters = (new ReflectionMethod(static::class, $method))->getParameters();
+
+        foreach($parameters as $parameter){
+            if ($parameter->name === "salt") {
                 return true;
             }
         }
+
         return false;
     }
 }

--- a/src/Models/OpenLDAP/User.php
+++ b/src/Models/OpenLDAP/User.php
@@ -3,11 +3,27 @@
 namespace LdapRecord\Models\OpenLDAP;
 
 use Illuminate\Contracts\Auth\Authenticatable;
+use LdapRecord\Models\Concerns\HasPassword;
 use LdapRecord\Models\Concerns\CanAuthenticate;
 
 class User extends Entry implements Authenticatable
 {
+    use HasPassword;
     use CanAuthenticate;
+
+    /**
+     * The password's attribute name.
+     *
+     * @var string
+     */
+    protected $passwordAttribute = 'userpassword';
+
+    /**
+     * The password's hash method.
+     *
+     * @var string
+     */
+    protected $passwordHashMethod = 'ssha';
 
     /**
      * The object classes of the LDAP model.

--- a/tests/Models/ActiveDirectory/UserTest.php
+++ b/tests/Models/ActiveDirectory/UserTest.php
@@ -12,10 +12,22 @@ use LdapRecord\Models\ActiveDirectory\Scopes\RejectComputerObjectClass;
 
 class UserTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Container::addConnection(new Connection());
+    }
+
+    protected function tearDown(): void
+    {
+        Container::reset();
+
+        parent::tearDown();
+    }
+
     public function test_setting_password_requires_secure_connection()
     {
-        Container::addConnection(new Connection());
-
         $this->expectException(ConnectionException::class);
 
         new User(['unicodepwd' => 'password']);
@@ -23,11 +35,9 @@ class UserTest extends TestCase
 
     public function test_changing_password_requires_secure_connection()
     {
-        Container::addConnection(new Connection());
+        $user = (new User())->setRawAttributes(['dn' => 'foo']);
 
         $this->expectException(ConnectionException::class);
-
-        $user = (new User())->setRawAttributes(['dn' => 'foo']);
 
         $user->unicodepwd = ['old', 'new'];
     }
@@ -75,8 +85,6 @@ class UserTest extends TestCase
 
     public function test_scope_where_has_mailbox_is_applied()
     {
-        Container::addConnection(new Connection());
-
         $filters = User::whereHasMailbox()->filters;
 
         $this->assertEquals($filters['and'][4]['field'], 'msExchMailboxGuid');

--- a/tests/Models/Attributes/PasswordTest.php
+++ b/tests/Models/Attributes/PasswordTest.php
@@ -22,132 +22,74 @@ class PasswordTest extends TestCase
 
     public function test_ssha()
     {
-        $password1 = Password::ssha('password');
-        $password2 = Password::ssha('password');
+        $password = Password::ssha('password');
 
         $this->assertNotEquals(
-            $password1,
-            $password2
+            $password,
+            Password::ssha('password')
         );
 
         $this->assertEquals(
-            $password1, 
-            Password::ssha('password', Password::getSalt($password1))
+            $password,
+            Password::ssha('password', Password::getSalt($password))
         );
     }
 
     public function test_ssha256()
     {
-        $password1 = Password::ssha256('password');
-        $password2 = Password::ssha256('password');
+        $password = Password::ssha256('password');
 
-        $this->assertNotEquals(
-            $password1,
-            $password2
-        );
+        $this->assertNotEquals($password, Password::ssha256('password'));
 
-        $this->assertEquals(
-            $password1, 
-            Password::ssha256('password', Password::getSalt($password1))
-        );        
+        $this->assertEquals($password, Password::ssha256('password', Password::getSalt($password)));
     }
 
     public function test_ssha384()
     {
-        $password1 = Password::ssha384('password');
-        $password2 = Password::ssha384('password');
+        $password = Password::ssha384('password');
 
-        $this->assertNotEquals(
-            $password1,
-            $password2
-        );
-
-        $this->assertEquals(
-            $password1, 
-            Password::ssha384('password', Password::getSalt($password1))
-        );
+        $this->assertNotEquals($password, Password::ssha384('password'));
+        $this->assertEquals($password, Password::ssha384('password', Password::getSalt($password)));
     }
 
     public function test_ssha512()
     {
-        $password1 = Password::ssha512('password');
-        $password2 = Password::ssha512('password');
+        $password = Password::ssha512('password');
 
-        $this->assertNotEquals(
-            $password1,
-            $password2
-        );
-
-        $this->assertEquals(
-            $password1, 
-            Password::ssha512('password', Password::getSalt($password1))
-        );
+        $this->assertNotEquals($password, Password::ssha512('password'));
+        $this->assertEquals($password, Password::ssha512('password', Password::getSalt($password)));
     }
 
     public function test_smd5()
     {
-        $password1 = Password::smd5('password');
-        $password2 = Password::smd5('password');
+        $password = Password::smd5('password');
 
-        $this->assertNotEquals(
-            $password1,
-            $password2
-        );
-
-        $this->assertEquals(
-            $password1, 
-            Password::smd5('password', Password::getSalt($password1))
-        );
+        $this->assertNotEquals($password, Password::smd5('password'));
+        $this->assertEquals($password, Password::smd5('password', Password::getSalt($password)));
     }
-
-
 
     public function test_md5crypt()
     {
-        $password1 = Password::md5crypt('password');
-        $password2 = Password::md5crypt('password');
+        $password = Password::md5crypt('password');
 
-        $this->assertNotEquals(
-            $password1,
-            $password2
-        );
-
-        $this->assertEquals(
-            $password1, 
-            Password::md5crypt('password', Password::getSalt($password1))
-        );
+        $this->assertNotEquals($password, Password::md5crypt('password'));
+        $this->assertEquals($password, Password::md5crypt('password', Password::getSalt($password)));
     }
 
     public function test_sha256crypt()
     {
-        $password1 = Password::sha256crypt('password');
-        $password2 = Password::sha256crypt('password');
+        $password = Password::sha256crypt('password');
 
-        $this->assertNotEquals(
-            $password1,
-            $password2
-        );
-
-        $this->assertEquals(
-            $password1, 
-            Password::sha256crypt('password', Password::getSalt($password1))
-        );
+        $this->assertNotEquals($password, Password::sha256crypt('password'));
+        $this->assertEquals($password, Password::sha256crypt('password', Password::getSalt($password)));
     }
 
     public function test_sha512crypt()
     {
-        $password1 = Password::sha512crypt('password');
-        $password2 = Password::sha512crypt('password');
+        $password = Password::sha512crypt('password');
 
-        $this->assertNotEquals(
-            $password1,
-            $password2
-        );
-
-        $this->assertEquals(
-            $password1, 
-            Password::sha512crypt('password', Password::getSalt($password1))
-        );
+        $this->assertNotEquals($password, Password::sha512crypt('password'));
+        $this->assertEquals($password, Password::sha512crypt('password', Password::getSalt($password)));
     }
 
     // Unsalted Hash Tests. //

--- a/tests/Models/Attributes/PasswordTest.php
+++ b/tests/Models/Attributes/PasswordTest.php
@@ -22,41 +22,131 @@ class PasswordTest extends TestCase
 
     public function test_ssha()
     {
+        $password1 = Password::ssha('password');
+        $password2 = Password::ssha('password');
+
         $this->assertNotEquals(
-            Password::ssha('password'),
-            Password::ssha('password')
+            $password1,
+            $password2
+        );
+
+        $this->assertEquals(
+            $password1, 
+            Password::ssha('password', Password::getSalt($password1))
         );
     }
 
     public function test_ssha256()
     {
+        $password1 = Password::ssha256('password');
+        $password2 = Password::ssha256('password');
+
         $this->assertNotEquals(
-            Password::ssha256('password'),
-            Password::ssha256('password')
+            $password1,
+            $password2
         );
+
+        $this->assertEquals(
+            $password1, 
+            Password::ssha256('password', Password::getSalt($password1))
+        );        
     }
 
     public function test_ssha384()
     {
+        $password1 = Password::ssha384('password');
+        $password2 = Password::ssha384('password');
+
         $this->assertNotEquals(
-            Password::ssha384('password'),
-            Password::ssha384('password')
+            $password1,
+            $password2
+        );
+
+        $this->assertEquals(
+            $password1, 
+            Password::ssha384('password', Password::getSalt($password1))
         );
     }
 
     public function test_ssha512()
     {
+        $password1 = Password::ssha512('password');
+        $password2 = Password::ssha512('password');
+
         $this->assertNotEquals(
-            Password::ssha512('password'),
-            Password::ssha512('password')
+            $password1,
+            $password2
+        );
+
+        $this->assertEquals(
+            $password1, 
+            Password::ssha512('password', Password::getSalt($password1))
         );
     }
 
     public function test_smd5()
     {
+        $password1 = Password::smd5('password');
+        $password2 = Password::smd5('password');
+
         $this->assertNotEquals(
-            Password::smd5('password'),
-            Password::smd5('password')
+            $password1,
+            $password2
+        );
+
+        $this->assertEquals(
+            $password1, 
+            Password::smd5('password', Password::getSalt($password1))
+        );
+    }
+
+
+
+    public function test_md5crypt()
+    {
+        $password1 = Password::md5crypt('password');
+        $password2 = Password::md5crypt('password');
+
+        $this->assertNotEquals(
+            $password1,
+            $password2
+        );
+
+        $this->assertEquals(
+            $password1, 
+            Password::md5crypt('password', Password::getSalt($password1))
+        );
+    }
+
+    public function test_sha256crypt()
+    {
+        $password1 = Password::sha256crypt('password');
+        $password2 = Password::sha256crypt('password');
+
+        $this->assertNotEquals(
+            $password1,
+            $password2
+        );
+
+        $this->assertEquals(
+            $password1, 
+            Password::sha256crypt('password', Password::getSalt($password1))
+        );
+    }
+
+    public function test_sha512crypt()
+    {
+        $password1 = Password::sha512crypt('password');
+        $password2 = Password::sha512crypt('password');
+
+        $this->assertNotEquals(
+            $password1,
+            $password2
+        );
+
+        $this->assertEquals(
+            $password1, 
+            Password::sha512crypt('password', Password::getSalt($password1))
         );
     }
 

--- a/tests/Models/Attributes/PasswordTest.php
+++ b/tests/Models/Attributes/PasswordTest.php
@@ -191,4 +191,26 @@ class PasswordTest extends TestCase
             Password::md5('password')
         );
     }
+
+    // Utility tests. //
+
+    public function test_get_hash_method()
+    {
+        $password = '{CRYPT}$6$77JasHs4YajlH$882VlypqZqKXT0d1vQsdBoCLHjYTzqRnxwy3qKiBCARaHvXhhQPv80JBIsfv25pm/fTLAc0dxdW1DTHA7e5QU1';
+
+        $this->assertEquals('CRYPT', Password::getHashMethod($password));
+        $this->assertNull(Password::getHashMethod('invalid'));
+    }
+
+    public function test_get_hash_method_and_algo()
+    {
+        $password = '{CRYPT}$6$77JasHs4YajlH$882VlypqZqKXT0d1vQsdBoCLHjYTzqRnxwy3qKiBCARaHvXhhQPv80JBIsfv25pm/fTLAc0dxdW1DTHA7e5QU1';
+
+        [$method, $algo] = Password::getHashMethodAndAlgo($password);
+
+        $this->assertEquals('CRYPT', $method);
+        $this->assertEquals('6', $algo);
+
+        $this->assertNull(Password::getHashMethodAndAlgo('invalid'));
+    }
 }

--- a/tests/Models/OpenLDAP/UserTest.php
+++ b/tests/Models/OpenLDAP/UserTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace LdapRecord\Tests\Models\OpenLDAP;
+
+use LdapRecord\Connection;
+use LdapRecord\Container;
+use LdapRecord\Tests\TestCase;
+use LdapRecord\Models\OpenLDAP\User;
+use LdapRecord\Models\Attributes\Password;
+
+class UserTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Container::addConnection(new Connection());
+    }
+
+    protected function tearDown(): void
+    {
+        Container::reset();
+
+        parent::tearDown();
+    }
+
+    public function test_settings_users_password_uses_ssha_algo()
+    {
+        $user = new OpenLDAPUserTestStub();
+
+        $user->password = 'secret';
+
+        $hashedPassword = $user->getModifications()[0]['values'][0];
+
+        $this->assertEquals('SSHA', Password::getHashMethod($hashedPassword));
+    }
+
+    public function test_algo_is_automatically_detected_when_changing_a_users_password()
+    {
+        $user = (new OpenLDAPUserTestStub)->setRawAttributes([
+            'userpassword' => [
+                '{MD5}Xr4ilOzQ4PCOq3aQ0qbuaQ=='
+            ]
+        ]);
+
+        $user->password = ['secret', 'new-secret'];
+
+        [$old, $new] = $user->getModifications();
+
+        $this->assertEquals('MD5', Password::getHashMethod($old['values'][0]));
+        $this->assertEquals('MD5', Password::getHashMethod($new['values'][0]));
+
+        $this->assertEquals('{MD5}6Kr5FZqDbwmgv+SEBnfifw==', $new['values'][0]);
+    }
+
+    public function test_algo_and_salt_is_automatically_detected_when_changing_a_users_password()
+    {
+        $pass = Password::sha512crypt('secret');
+
+        $user = (new OpenLDAPUserTestStub)->setRawAttributes([
+            'userpassword' => [
+                $pass,
+            ]
+        ]);
+
+        $user->password = ['secret', 'new-secret'];
+
+        [$old, $new] = $user->getModifications();
+
+        $this->assertEquals('CRYPT', Password::getHashMethod($old['values'][0]));
+        $this->assertEquals('CRYPT', Password::getHashMethod($new['values'][0]));
+
+        [, $oldAlgo] = Password::getHashMethodAndAlgo($old['values'][0]);
+        $this->assertEquals(Password::CRYPT_SALT_TYPE_SHA512, $oldAlgo);
+
+
+        [, $newAlgo] = Password::getHashMethodAndAlgo($new['values'][0]);
+        $this->assertEquals(Password::CRYPT_SALT_TYPE_SHA512, $newAlgo);
+    }
+}
+
+class OpenLDAPUserTestStub extends User
+{
+    protected function validateSecureConnection()
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
setPasswordAttribute(['old-password', 'new-password']) was not working with salted password hashes. Therefor LDAP_MODIFY_BATCH_REMOVE field on OpenLdap. Now models can detect the current password hash and use the current salt from the existing password to hash the old password for replacement.