### PR TITLE
Add psalm.xml config file

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="7"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>


### PR DESCRIPTION
Hello,

This simple change adds a `psalm.xml` configuration file for [Psalm](https://github.com/vimeo/psalm) static analyzer.

Add the `psalm.phar` (from the [releases page](https://github.com/vimeo/psalm/releases)) in your `$PATH` and just do `psalm` to get something like:

![2021-02-25-175920_1908x673_scrot](https://user-images.githubusercontent.com/3043706/109188615-65fe6200-7793-11eb-85a9-4776cc873239.png)

As you can see, a bunch of errors are found. Some that might be quite hard to spot without a tool like this one.

Best,
~Nico