### PR TITLE
Bump minimum `tightenco/collect` library to ^5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "psr/log": "^1.0",
         "psr/simple-cache": "^1.0",
         "nesbot/carbon": "^1.0|^2.0",
-        "tightenco/collect": "^5.0|^6.0|^7.0|^8.0",
+        "tightenco/collect": "^5.6|^6.0|^7.0|^8.0",
         "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
`tightenco/collect` <5.6 has an older namespace which is incompatible with version 5.6 onwards. This should have no minimum requirement issues as 5.6 requires PHP 7.1 and this package is PHP 7.2 minimum.

I only [noticed this](https://github.com/iter8-au/ldaprecord-bundle/runs/2129510303?check_suite_focus=true) when setting up GitHub Actions for my [Symfony Bundle](https://github.com/iter8-au/ldaprecord-bundle) of this great package.