### PR TITLE
Fix typo in docblock and remove a few whitespaces

### DIFF
--- a/src/Query/Model/ActiveDirectoryBuilder.php
+++ b/src/Query/Model/ActiveDirectoryBuilder.php
@@ -117,7 +117,7 @@ class ActiveDirectoryBuilder extends Builder
      *
      * @param string  $dn
      * @param boolean $nested
-     * 
+     *
      * @return $this
      */
     public function whereNotMemberof($dn, $nested = false)
@@ -147,7 +147,7 @@ class ActiveDirectoryBuilder extends Builder
      *
      * @param string  $dn
      * @param boolean $nested
-     * 
+     *
      * @return $this
      */
     public function orWhereNotMemberof($dn, $nested = false)
@@ -220,10 +220,10 @@ class ActiveDirectoryBuilder extends Builder
     /**
      * Execute the callback with a nested match attribute.
      *
-     * @param Clousre $callback
+     * @param Closure $callback
      * @param string  $attribute
      * @param boolean $nested
-     * 
+     *
      * @return $this
      */
     protected function nestedMatchQuery(Closure $callback, $attribute, $nested = false)
@@ -232,12 +232,12 @@ class ActiveDirectoryBuilder extends Builder
             $nested ? $this->makeNestedMatchAttribute($attribute) : $attribute
         );
     }
-    
+
     /**
      * Make a "nested match" filter attribute for querying descendants.
      *
      * @param string $attribute
-     * 
+     *
      * @return string
      */
     protected function makeNestedMatchAttribute($attribute)


### PR DESCRIPTION
I'm glad you fixed a lot of the psalm reported issues ;) Static analysis in php is very useful.

This is just a small typo fix to bring it down from 1 to 0!

Still 401 other issues, but at least no errors now!

Now that you don't have any errors anymore you can add it to the tests!