### PR TITLE
Don't use return on void functions

### DIFF
--- a/src/Events/Logger.php
+++ b/src/Events/Logger.php
@@ -39,11 +39,16 @@ class Logger
     {
         switch (true) {
             case $event instanceof AuthEvent:
-                return $this->auth($event);
+                $this->auth($event);
+                break;
             case $event instanceof ModelEvent:
-                return $this->model($event);
+                $this->model($event);
+                break;
             case $event instanceof QueryEvent:
-                return $this->query($event);
+                $this->query($event);
+                break;
+            default:
+                return;
         }
     }
 


### PR DESCRIPTION
Also, is there a reason why you're not using return typing? I mean have `function blah(): void` instead of `@return void` in the docblock.