### PR TITLE
Replace deprecated tightenco/collect package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "psr/log": "^1.0",
         "psr/simple-cache": "^1.0",
         "nesbot/carbon": "^1.0|^2.0",
-        "tightenco/collect": "^5.6|^6.0|^7.0|^8.0",
+        "illuminate/collections": "^8.0",
         "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {

--- a/src/Query/Collection.php
+++ b/src/Query/Collection.php
@@ -3,7 +3,7 @@
 namespace LdapRecord\Query;
 
 use LdapRecord\Models\Model;
-use Tightenco\Collect\Support\Collection as BaseCollection;
+use Illuminate\Support\Collection as BaseCollection;
 
 class Collection extends BaseCollection
 {


### PR DESCRIPTION
`tightenco/collect` was just a repackaging of Laravel's collection code. Since Laravel 8.0 the `illuminate/collection` package has been available as a separate requirement. This just removes the deprecated package, replacing it with the official one.