### PR TITLE
Allow resolving host list from SRV records

### DIFF
--- a/src/Configuration/DomainConfiguration.php
+++ b/src/Configuration/DomainConfiguration.php
@@ -24,6 +24,12 @@ class DomainConfiguration
         // An array of LDAP hosts.
         'hosts' => [],
 
+        // Get host list from SRV record
+        'host_is_dns_srv' => false,
+
+        // Get host list from SRV record assuming host name is a base AD domain
+        'host_is_ad_dns_srv' => false,
+
         // The global LDAP operation timeout limit in seconds.
         'timeout' => 5,
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -532,10 +532,16 @@ class Connection
 
         $hosts = [];
         if ($record_name) {
-            $dns_result = dns_get_record($record_name, DNS_SRV);
+            if ($dns_result = dns_get_record($record_name, DNS_SRV)) {
+                $dns_collection = collect($dns_result)->mapToGroups(function ($item, $key) {
+                    return [$item['pri'] => $item];
+                })->transform(function ($item, $key) {
+                    return $item->sortByDesc('weight');
+                })->flatten(1);
 
-            foreach ($dns_result as $res) {
-                $hosts[] = $res['target'];
+                foreach ($dns_collection as $res) {
+                    $hosts[] = $res['target'];
+                }
             }
         }
 

--- a/tests/Configuration/DomainConfigurationTest.php
+++ b/tests/Configuration/DomainConfigurationTest.php
@@ -43,6 +43,8 @@ class DomainConfigurationTest extends TestCase
         $this->assertEmpty($config->get('base_dn'));
         $this->assertFalse($config->get('use_ssl'));
         $this->assertFalse($config->get('use_tls'));
+        $this->assertFalse($config->get('host_is_dns_srv'));
+        $this->assertFalse($config->get('host_is_ad_dns_srv'));
         $this->assertEquals([], $config->get('options'));
     }
 
@@ -91,6 +93,8 @@ class DomainConfigurationTest extends TestCase
             'password' => '',
             'use_ssl' => false,
             'use_tls' => false,
+            'host_is_dns_srv' => false,
+            'host_is_ad_dns_srv' => false,
             'follow_referrals' => false,
             'options' => [],
         ], $config->all());


### PR DESCRIPTION
When querying against Active Directory servers with real SSL certificates, the SSL certificate might match the hostname of the server (for example, `dc1.example.com`, but no the domain name. For security reasons, looking up the correct server list in DNS will allow validating the hostname correctly.

This is difficult to write tests for without some known DNS servers (for example, Spatie hosts records to test their `spatie/dns` package).