### PR TITLE
Fix applying distinguished name to Model's when `fill()`'ed or set via attribute

### DIFF
--- a/src/Models/ActiveDirectory/Entry.php
+++ b/src/Models/ActiveDirectory/Entry.php
@@ -109,10 +109,9 @@ class Entry extends BaseEntry implements ActiveDirectory
             }
         });
 
-        $this->save([
-            'isDeleted' => null,
-            'distinguishedName' => $newDn,
-        ]);
+        $this->setRawAttribute('distinguishedname', $newDn);
+
+        $this->save(['isDeleted' => null]);
     }
 
     /**

--- a/src/Models/Concerns/HasAttributes.php
+++ b/src/Models/Concerns/HasAttributes.php
@@ -707,9 +707,9 @@ trait HasAttributes
     }
 
     /**
-     * Set an attribute value by the specified key and sub-key.
+     * Set an attribute value by the specified key.
      *
-     * @param mixed $key
+     * @param string $key
      * @param mixed $value
      *
      * @return $this
@@ -732,6 +732,23 @@ trait HasAttributes
             $value = $this->castAttributeAsJson($key, $value);
         }
 
+        $this->attributes[$key] = Arr::wrap($value);
+
+        return $this;
+    }
+
+    /**
+     * Set an attribute on the model. No checking is done.
+     *
+     * @param string $key
+     * @param mixed  $value
+     *
+     * @return $this
+     */
+    public function setRawAttribute($key, $value)
+    {
+        $key = $this->normalizeAttributeKey($key);
+        
         $this->attributes[$key] = Arr::wrap($value);
 
         return $this;

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -217,7 +217,7 @@ abstract class Model implements ArrayAccess, Arrayable, JsonSerializable
     /**
      * A mutator for setting the models distinguished name.
      *
-     * @param strin $dn
+     * @param string $dn
      *
      * @return $this
      */

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -205,13 +205,37 @@ abstract class Model implements ArrayAccess, Arrayable, JsonSerializable
      *
      * @param string $dn
      *
-     * @return static
+     * @return $this
      */
     public function setDn($dn)
     {
         $this->dn = (string) $dn;
 
         return $this;
+    }
+
+    /**
+     * A mutator for setting the models distinguished name.
+     *
+     * @param strin $dn
+     *
+     * @return $this
+     */
+    public function setDnAttribute($dn)
+    {
+        return $this->setRawAttribute('dn', $dn)->setDn($dn);
+    }
+
+    /**
+     * A mutator for setting the models distinguished name.
+     *
+     * @param string $dn
+     *
+     * @return $this
+     */
+    public function setDistinguishedNameAttribute($dn)
+    {
+        return $this->setRawAttribute('distinguishedname', $dn)->setDn($dn);
     }
 
     /**
@@ -274,6 +298,18 @@ abstract class Model implements ArrayAccess, Arrayable, JsonSerializable
     public static function all($attributes = ['*'])
     {
         return static::query()->select($attributes)->paginate();
+    }
+
+    /**
+     * Make a new model instance.
+     *
+     * @param array $attributes
+     *
+     * @return static
+     */
+    public static function make($attributes = [])
+    {
+        return new static($attributes);
     }
 
     /**

--- a/tests/Models/ModelTest.php
+++ b/tests/Models/ModelTest.php
@@ -665,7 +665,7 @@ class ModelTest extends TestCase
         $this->assertEquals('cn=John\5c\2c\3d\2b\3c\3e\3b\5c\23Doe,dc=local,dc=com', $model->getCreatableDn());
     }
 
-    public function test_setting_dn_attributes_set_distinguished_name_on_model_if_present()
+    public function test_setting_dn_attributes_set_distinguished_name_on_model()
     {
         $this->assertEquals('foo', (new Entry(['distinguishedname' => 'foo']))->getDn());
         $this->assertEquals('foo', Entry::make(['distinguishedname' => 'foo'])->getDn());

--- a/tests/Models/ModelTest.php
+++ b/tests/Models/ModelTest.php
@@ -664,6 +664,22 @@ class ModelTest extends TestCase
 
         $this->assertEquals('cn=John\5c\2c\3d\2b\3c\3e\3b\5c\23Doe,dc=local,dc=com', $model->getCreatableDn());
     }
+    
+    public function test_setting_dn_attributes_set_distinguished_name_on_model_if_present()
+    {
+        $this->assertEquals('foo', (new Entry(['distinguishedname' => 'foo']))->getDn());
+        $this->assertEquals('foo', Entry::make(['distinguishedname' => 'foo'])->getDn());
+        
+        $model = new Entry();
+        $model->dn = 'foo';
+        $this->assertEquals('foo', $model->getDn());
+        $this->assertEquals(['foo'], $model->getAttributes()['dn']);
+
+        $model = new Entry();
+        $model->distinguishedname = 'foo';
+        $this->assertEquals('foo', $model->getDn());
+        $this->assertEquals(['foo'], $model->getAttributes()['distinguishedname']);
+    }
 }
 
 class ModelCreateTestStub extends Model


### PR DESCRIPTION
Related #354 

## Changed
- When models have their `dn` or `distinguishedname` attribute set, the models `$dn` property is now properly updated to its value

## Added
- `Model::make()` method for making new model instances fluently without saving them
- `$model->setRawAttribute($key, $value)` has been added to allow direct access to the `$attributes` property without triggering mutators