### PR TITLE
Simplify shouldContinue()

### DIFF
--- a/src/Query/Pagination/AbstractPaginator.php
+++ b/src/Query/Pagination/AbstractPaginator.php
@@ -87,7 +87,7 @@ abstract class AbstractPaginator
     {
         $cookie = (string) $this->fetchCookie();
 
-        return ! empty($cookie) || $cookie === '0';
+        return $cookie !== '';
     }
 
     /**


### PR DESCRIPTION
Since `$cookie` is always a string we can simplify the way to check if it's empty.