### PR TITLE
Feature - Server Side Sorting

### DIFF
--- a/src/Query/Pagination/Paginator.php
+++ b/src/Query/Pagination/Paginator.php
@@ -37,28 +37,6 @@ class Paginator extends AbstractPaginator
      */
     protected function updateServerControls(LdapInterface $ldap, $resource)
     {
-        $errorCode = 0;
-        $dn = $errorMessage = $refs = null;
-
-        $ldap->parseResult(
-            $resource,
-            $errorCode,
-            $dn,
-            $errorMessage,
-            $refs,
-            $this->query->controls
-        );
-
-        $this->resetPageSize();
-    }
-
-    /**
-     * Reset the page control page size.
-     *
-     * @return void
-     */
-    protected function resetPageSize()
-    {
         $this->query->controls[LDAP_CONTROL_PAGEDRESULTS]['value']['size'] = $this->perPage;
     }
 
@@ -67,6 +45,6 @@ class Paginator extends AbstractPaginator
      */
     protected function resetServerControls(LdapInterface $ldap)
     {
-        $this->query->controls = [];
+        unset($this->query->controls[LDAP_CONTROL_PAGEDRESULTS]);
     }
 }

--- a/tests/Models/ModelScopeTest.php
+++ b/tests/Models/ModelScopeTest.php
@@ -100,9 +100,12 @@ class ModelScopeTest extends TestCase
     public function test_scopes_do_not_impact_model_refresh()
     {
         DirectoryFake::setup()->getLdapConnection()->expect(
-            LdapFake::operation('read')->once()->with('cn=John Doe,dc=local,dc=com')->andReturn([
-                ['dn' => 'cn=John Doe,dc=local,dc=com'],
-            ])
+            [
+                LdapFake::operation('parseResult')->once(),
+                LdapFake::operation('read')->once()->with('cn=John Doe,dc=local,dc=com')->andReturn([
+                    ['dn' => 'cn=John Doe,dc=local,dc=com'],
+                ])
+            ]
         );
 
         $model = (new ModelWithDnScopeTestStub())
@@ -116,9 +119,12 @@ class ModelScopeTest extends TestCase
     public function test_scopes_do_not_impact_model_find()
     {
         DirectoryFake::setup()->getLdapConnection()->expect(
-            LdapFake::operation('read')->once()->with('cn=John Doe,dc=local,dc=com')->andReturn([
-                ['dn' => 'cn=John Doe,dc=local,dc=com'],
-            ])
+            [
+                LdapFake::operation('parseResult')->once(),
+                LdapFake::operation('read')->once()->with('cn=John Doe,dc=local,dc=com')->andReturn([
+                    ['dn' => 'cn=John Doe,dc=local,dc=com'],
+                ])
+            ]
         );
 
         $model = ModelWithDnScopeTestStub::find('cn=John Doe,dc=local,dc=com');

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1258,6 +1258,7 @@ class BuilderTest extends TestCase
                 LdapFake::operation('setOption')->with(LDAP_OPT_PROTOCOL_VERSION, 3)->once(),
                 LdapFake::operation('setOption')->with(LDAP_OPT_NETWORK_TIMEOUT, 5)->once(),
                 LdapFake::operation('setOption')->with(LDAP_OPT_REFERRALS, 0)->once(),
+                LdapFake::operation('parseResult')->once(),
                 LdapFake::operation('read')->once()->with($dn, '(objectclass=*)', ['*'])->andReturn($results),
             ]);
 


### PR DESCRIPTION
This PR introduces the ability to sort LDAP results server-side, instead of relying on client side sorting, which can be resource intensive with large sets of results. It also works with paginated requests (which means it also works via chunking).

This PR also introduces a new public property `$controlsResponse` on the query builder which will be populated after a query is executed, allowing us to look at the controls sent back from the server and identify any potential issues.