### PR TITLE
Fix model un-serialization

### DIFF
--- a/src/Models/ActiveDirectory/Entry.php
+++ b/src/Models/ActiveDirectory/Entry.php
@@ -154,7 +154,7 @@ class Entry extends BaseEntry implements ActiveDirectory
     }
 
     /**
-     * Converts attributes for JSON serialization.
+     * Convert the attributes for JSON serialization.
      *
      * @param array $attributes
      *
@@ -164,11 +164,40 @@ class Entry extends BaseEntry implements ActiveDirectory
     {
         $attributes = parent::convertAttributesForJson($attributes);
 
+        // If the model has a SID set, we need to convert it to its
+        // string format, due to it being in binary. Otherwise
+        // we will receive a JSON serialization exception.
         if (isset($attributes[$this->sidKey])) {
-            // If the model has a SID set, we need to convert it to its
-            // string format, due to it being in binary. Otherwise
-            // we will receive a JSON serialization exception.
             $attributes[$this->sidKey] = [$this->getConvertedSid(
+                Arr::first($attributes[$this->sidKey])
+            )];
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Convert the attributes from JSON serialization.
+     *
+     * @param array $attributes
+     *
+     * @return array
+     */
+    protected function convertAttributesFromJson(array $attributes = [])
+    {
+        $attributes = parent::convertAttributesFromJson($attributes);
+
+        // Here we are converting the model's GUID and SID attributes
+        // back to their original values from serialization, so that
+        // their original value may be used and compared against.
+        if (isset($attributes[$this->guidKey])) {
+            $attributes[$this->guidKey] = [$this->getBinaryGuid(
+                Arr::first($attributes[$this->guidKey])
+            )];
+        }
+
+        if (isset($attributes[$this->sidKey])) {
+            $attributes[$this->sidKey] = [$this->getBinarySid(
                 Arr::first($attributes[$this->sidKey])
             )];
         }

--- a/src/Models/Concerns/SerializesAndRestoresPropertyValues.php
+++ b/src/Models/Concerns/SerializesAndRestoresPropertyValues.php
@@ -2,6 +2,7 @@
 
 namespace LdapRecord\Models\Concerns;
 
+/** @mixin HasAttributes */
 trait SerializesAndRestoresPropertyValues
 {
     /**
@@ -35,6 +36,14 @@ trait SerializesAndRestoresPropertyValues
      */
     protected function getUnserializedPropertyValue($property, $value)
     {
+        if ($property === 'original') {
+            return $this->arrayToOriginal($value);
+        }
+
+        if ($property === 'attributes') {
+            return $this->arrayToAttributes($value);
+        }
+
         return $value;
     }
 }

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -674,7 +674,7 @@ abstract class Model implements ArrayAccess, Arrayable, JsonSerializable
     }
 
     /**
-     * Converts extra attributes for JSON serialization.
+     * Convert the attributes for JSON serialization.
      *
      * @param array $attributes
      *
@@ -691,6 +691,18 @@ abstract class Model implements ArrayAccess, Arrayable, JsonSerializable
             )];
         }
 
+        return $attributes;
+    }
+
+    /**
+     * Convert the attributes from JSON serialization.
+     *
+     * @param array $attributes
+     *
+     * @return array
+     */
+    protected function convertAttributesFromJson(array $attributes = [])
+    {
         return $attributes;
     }
 

--- a/tests/Unit/Models/ModelSerializationTest.php
+++ b/tests/Unit/Models/ModelSerializationTest.php
@@ -62,6 +62,9 @@ class ModelSerializationTest extends TestCase
         $this->assertEquals($model->getConvertedSid(), $unserializedAndUnencoded->getConvertedSid());
         $this->assertEquals($model->getConvertedGuid(), $unserializedAndUnencoded->getConvertedGuid());
 
+        $this->assertEquals($model->getOriginal()['objectsid'], $unserializedAndUnencoded->getOriginal()['objectsid']);
+        $this->assertEquals($model->getOriginal()['objectguid'], $unserializedAndUnencoded->getOriginal()['objectguid']);
+        
         $this->assertEquals($model->getAttributes()['objectsid'], $unserializedAndUnencoded->getAttributes()['objectsid']);
         $this->assertEquals($model->getAttributes()['objectguid'], $unserializedAndUnencoded->getAttributes()['objectguid']);
     }

--- a/tests/Unit/Models/ModelSerializationTest.php
+++ b/tests/Unit/Models/ModelSerializationTest.php
@@ -12,17 +12,14 @@ use LdapRecord\Tests\TestCase;
 
 class ModelSerializationTest extends TestCase
 {
-    public function testModelWithTimestampsandBinaryValuesCanBeUnserializedAndRestored()
+    public function testModelWithTimestampsCanBeSerializedAndEncoded()
     {
-        $guid = new Guid('2bba564a-4f95-4cb0-97b0-94c0e3458621');
-        $sid = new Sid('S-1-5-21-1004336348-1177238915-682003330-512');
-
-        $timestamp = (new Timestamp('windows-int'))->fromDateTime(new DateTime());
-
+        $whenchanged = (new Timestamp('windows'))->fromDateTime(new DateTime());
+        $lastlogon = (new Timestamp('windows-int'))->fromDateTime(new DateTime());
+        
         $model = (new User())->setRawAttributes([
-            'lastlogon' => [(string) $timestamp],
-            'objectguid' => [$guid->getBinary()],
-            'objectsid' => [$sid->getBinary()],
+            'whenchanged' => [(string) $whenchanged],
+            'lastlogon' => [(string) $lastlogon],
         ]);
 
         $encodedAndSerialized = json_encode(serialize(clone $model));
@@ -36,13 +33,10 @@ class ModelSerializationTest extends TestCase
         $this->assertTrue($model->is($unserializedAndUnencoded));
 
         $this->assertEquals($model->getOriginal()['lastlogon'], $unserializedAndUnencoded->getOriginal()['lastlogon']);
+        $this->assertEquals($model->getOriginal()['whenchanged'], $unserializedAndUnencoded->getOriginal()['whenchanged']);
+
         $this->assertEquals($model->getAttributes()['lastlogon'], $unserializedAndUnencoded->getAttributes()['lastlogon']);
-
-        $this->assertEquals($model->getOriginal()['objectguid'], $unserializedAndUnencoded->getOriginal()['objectguid']);
-        $this->assertEquals($model->getOriginal()['objectsid'], $unserializedAndUnencoded->getOriginal()['objectsid']);
-
-        $this->assertEquals($model->getAttributes()['objectguid'], $unserializedAndUnencoded->getAttributes()['objectguid']);
-        $this->assertEquals($model->getAttributes()['objectsid'], $unserializedAndUnencoded->getAttributes()['objectsid']);
+        $this->assertEquals($model->getAttributes()['whenchanged'], $unserializedAndUnencoded->getAttributes()['whenchanged']);
     }
 
     public function testModelWithBinaryGuidAndSidCanBeSerializedAndEncoded()
@@ -65,10 +59,10 @@ class ModelSerializationTest extends TestCase
 
         $this->assertTrue($model->is($unserializedAndUnencoded));
 
-        $this->assertEquals($model->getConvertedGuid(), $unserializedAndUnencoded->getConvertedGuid());
         $this->assertEquals($model->getConvertedSid(), $unserializedAndUnencoded->getConvertedSid());
-
-        $this->assertNotEquals($model->getAttributes()['objectguid'], $unserializedAndUnencoded->getAttributes()['objectguid']);
-        $this->assertNotEquals($model->getAttributes()['objectsid'], $unserializedAndUnencoded->getAttributes()['objectsid']);
+        $this->assertEquals($model->getConvertedGuid(), $unserializedAndUnencoded->getConvertedGuid());
+        
+        $this->assertEquals($model->getAttributes()['objectsid'], $unserializedAndUnencoded->getAttributes()['objectsid']);
+        $this->assertEquals($model->getAttributes()['objectguid'], $unserializedAndUnencoded->getAttributes()['objectguid']);
     }
 }


### PR DESCRIPTION
Closes #457

This PR implements un-serialization logic to convert transformed values back into their true LDAP counterparts.