### PR TITLE
Add ability to chunk relations recursively

### DIFF
--- a/src/Models/Collection.php
+++ b/src/Models/Collection.php
@@ -10,6 +10,18 @@ use LdapRecord\Support\Arr;
 class Collection extends QueryCollection
 {
     /**
+     * Get a collection of the model's distinguished names.
+     *
+     * @return static
+     */
+    public function modelDns()
+    {
+        return $this->map(function (Model $model) {
+            return $model->getDn();
+        });
+    }
+
+    /**
      * Determine if the collection contains all of the given models, or any models.
      *
      * @param mixed $models

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -513,13 +513,13 @@ class Builder
      * Execute a callback over each item while chunking.
      *
      * @param Closure $callback
-     * @param int     $count
+     * @param int     $pageSize
      *
      * @return bool
      */
-    public function each(Closure $callback, $count = 1000)
+    public function each(Closure $callback, $pageSize = 1000)
     {
-        return $this->chunk($count, function ($results) use ($callback) {
+        return $this->chunk($pageSize, function ($results) use ($callback) {
             foreach ($results as $key => $value) {
                 if ($callback($value, $key) === false) {
                     return false;


### PR DESCRIPTION
Closes https://github.com/DirectoryTree/LdapRecord/issues/409

This PR also adds:

- `Models\Collection::modelDns()` method to easily fetch all of the model's Distinguished Name's inside of a model collection. This is a parity feature of the Eloquent Collection `modelKeys()` method.
- `HasMany::each($callback)` method to iterate through each result of a chunked query via callback.