### PR TITLE
Properly set the LDAP batch modification type of password when user does not exist

### DIFF
--- a/src/Models/Concerns/CanAuthenticate.php
+++ b/src/Models/Concerns/CanAuthenticate.php
@@ -2,6 +2,7 @@
 
 namespace LdapRecord\Models\Concerns;
 
+/** @mixin \LdapRecord\Models\Model */
 trait CanAuthenticate
 {
     /**

--- a/src/Models/Concerns/HasEvents.php
+++ b/src/Models/Concerns/HasEvents.php
@@ -6,6 +6,7 @@ use Closure;
 use LdapRecord\Events\NullDispatcher;
 use LdapRecord\Models\Events\Event;
 
+/** @mixin \LdapRecord\Models\Model */
 trait HasEvents
 {
     /**

--- a/src/Models/Concerns/HasGlobalScopes.php
+++ b/src/Models/Concerns/HasGlobalScopes.php
@@ -6,6 +6,7 @@ use Closure;
 use InvalidArgumentException;
 use LdapRecord\Models\Scope;
 
+/** @mixin \LdapRecord\Models\Model */
 trait HasGlobalScopes
 {
     /**

--- a/src/Models/Concerns/HasPassword.php
+++ b/src/Models/Concerns/HasPassword.php
@@ -6,6 +6,7 @@ use LdapRecord\ConnectionException;
 use LdapRecord\LdapRecordException;
 use LdapRecord\Models\Attributes\Password;
 
+/** @mixin \LdapRecord\Models\Model */
 trait HasPassword
 {
     /**
@@ -143,10 +144,14 @@ trait HasPassword
      */
     protected function setPassword($password, $attribute)
     {
+        $modtype = $this->exists
+            ? LDAP_MODIFY_BATCH_REPLACE
+            : LDAP_MODIFY_BATCH_ADD;
+
         $this->addModification(
             $this->newBatchModification(
                 $attribute,
-                LDAP_MODIFY_BATCH_REPLACE,
+                $modtype,
                 [$password]
             )
         );

--- a/src/Models/Concerns/HasScopes.php
+++ b/src/Models/Concerns/HasScopes.php
@@ -2,6 +2,7 @@
 
 namespace LdapRecord\Models\Concerns;
 
+/** @mixin \LdapRecord\Models\Model */
 trait HasScopes
 {
     /**

--- a/src/Models/Concerns/HidesAttributes.php
+++ b/src/Models/Concerns/HidesAttributes.php
@@ -6,6 +6,8 @@ namespace LdapRecord\Models\Concerns;
  * @author Taylor Otwell
  *
  * @see https://laravel.com
+ * 
+ * @mixin \LdapRecord\Models\Model
  */
 trait HidesAttributes
 {

--- a/tests/Unit/Models/ActiveDirectory/UserTest.php
+++ b/tests/Unit/Models/ActiveDirectory/UserTest.php
@@ -51,7 +51,30 @@ class UserTest extends TestCase
 
         $user->unicodepwd = 'foo';
 
-        $this->assertEquals([Password::encode('foo')], $user->getModifications()[0]['values']);
+        $this->assertCount(1, $mods = $user->getModifications());
+
+        $this->assertEquals([
+            'attrib' => 'unicodepwd',
+            'modtype' => LDAP_MODIFY_BATCH_ADD,
+            'values' => [Password::encode('foo')],
+        ], $mods[0]);
+    }
+
+    public function test_set_password_on_existing_user()
+    {
+        $user = new UserPasswordTestStub();
+
+        $user->exists = true;
+
+        $user->unicodepwd = 'foo';
+
+        $this->assertCount(1, $mods = $user->getModifications());
+
+        $this->assertEquals([
+            'attrib' => 'unicodepwd',
+            'modtype' => LDAP_MODIFY_BATCH_REPLACE,
+            'values' => [Password::encode('foo')],
+        ], $mods[0]);
     }
 
     public function test_password_mutator_alias_works()


### PR DESCRIPTION
Closes #504 