### PR TITLE
Add ability to filter relations based on related object classes

### DIFF
--- a/src/Models/Relations/Relation.php
+++ b/src/Models/Relations/Relation.php
@@ -131,15 +131,27 @@ abstract class Relation
     }
 
     /**
-     * Only return objects matching the related object classes.
+     * Only return objects matching the related model's object classes.
      *
      * @return $this
      */
     public function onlyRelated()
     {
-        $this->query->andFilter(function (Builder $query) {
-            foreach ($this->related as $related) {
-                $query->whereIn('objectclass', $related::$objectClasses);
+        $relations = [];
+
+        foreach ($this->related as $related) {
+            $relations[$related] = $related::$objectClasses;
+        }
+
+        $relations = array_filter($relations);
+
+        if (empty($relations)) {
+            return $this;
+        }
+        
+        $this->query->andFilter(function (Builder $query) use ($relations) {
+            foreach ($relations as $relation => $objectClasses) {
+                $query->whereIn('objectclass', $objectClasses);
             }
         });
 

--- a/src/Models/Relations/Relation.php
+++ b/src/Models/Relations/Relation.php
@@ -123,6 +123,22 @@ abstract class Relation
     }
 
     /**
+     * Only return objects matching the related object classes.
+     *
+     * @return $this
+     */
+    public function onlyRelated()
+    {
+        $this->query->andFilter(function (Builder $query) {
+            foreach ($this->related as $related) {
+                $query->whereIn('objectclass', $related::$objectClasses);
+            }
+        });
+
+        return $this;
+    }
+
+    /**
      * Get the results of the relationship.
      *
      * @return Collection


### PR DESCRIPTION
Related https://github.com/DirectoryTree/LdapRecord/issues/484

This PR implements the ability for devs to apply a subsequent method call to relations when querying or defining them to reject any models that are returned from the query that do not have the object classes specified in their `$objectClasses` property:

**Applying Dynamically**:
```php
$group = Group::find('cn=accounting,dc=local,dc=com');

$group->members()->onlyRelated()->get();
```

**Applying in Relation Definition**:
```php
class Group extends Model
{
    public function members()
    {
        return $this->hasMany([User::class, Group::class])->onlyRelated();
    }
}
```