### PR TITLE
Run chunking in isolated connections

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -1365,8 +1365,8 @@ abstract class Model implements ArrayAccess, Arrayable, JsonSerializable
         $this->newQueryWithoutScopes()
             ->in($this->dn)
             ->listing()
-            ->chunk(250, function ($models) {
-                $models->each->delete($recursive = true);
+            ->each(function (Model $model) {
+                $model->delete($recursive = true);
             });
     }
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -568,7 +568,7 @@ class Builder
      */
     protected function runChunk($filter, $perPage, $isCritical)
     {
-        return $this->connection->run(function (LdapInterface $ldap) use ($filter, $perPage, $isCritical) {
+        return $this->connection->runInIsolation(function (LdapInterface $ldap) use ($filter, $perPage, $isCritical) {
             return (new LazyPaginator($this, $filter, $perPage, $isCritical))->execute($ldap);
         });
     }

--- a/tests/Integration/ConnectionTest.php
+++ b/tests/Integration/ConnectionTest.php
@@ -13,6 +13,22 @@ class ConnectionTest extends TestCase
         $this->assertTrue($conn->isConnected());
     }
 
+    public function test_replicate()
+    {
+        $conn = $this->makeConnection();
+
+        $conn->connect();
+
+        $clone = $conn->replicate();
+
+        $this->assertTrue($conn->isConnected());
+        $this->assertFalse($clone->isConnected());
+
+        $clone->connect();
+
+        $this->assertTrue($clone->isConnected());
+    }
+
     public function test_disconnect()
     {
         $conn = $this->makeConnection();

--- a/tests/Unit/ConnectionTest.php
+++ b/tests/Unit/ConnectionTest.php
@@ -86,6 +86,20 @@ class ConnectionTest extends TestCase
         $this->assertInstanceOf(Builder::class, (new Connection())->query());
     }
 
+    public function test_connections_can_be_replicated()
+    {
+        $conn = new Connection();
+
+        $replicate = $conn->replicate();
+
+        $this->assertInstanceOf(Connection::class, $replicate);
+
+        $this->assertFalse($conn === $replicate);
+
+        $this->assertTrue($conn->getConfiguration() === $replicate->getConfiguration());
+        $this->assertFalse($conn->getLdapConnection() === $replicate->getLdapConnection());
+    }
+
     public function test_plain_protocol_and_port_is_used_when_ssl_is_disabled()
     {
         $conn = new Connection(['hosts' => ['127.0.0.1'], 'use_ssl' => false]);

--- a/tests/Unit/Models/ModelQueryTest.php
+++ b/tests/Unit/Models/ModelQueryTest.php
@@ -339,13 +339,11 @@ class ModelQueryTest extends TestCase
 
         $leaf->shouldReceive('delete')->once()->andReturnTrue();
 
-        $shouldBeDeleted = new Collection([$leaf]);
-
         $query = m::mock(Builder::class);
         $query->shouldReceive('listing')->once()->andReturnSelf();
         $query->shouldReceive('in')->once()->with('foo')->andReturnSelf();
-        $query->shouldReceive('chunk')->once()->with(250, m::on(function ($callback) use ($shouldBeDeleted) {
-            $callback($shouldBeDeleted);
+        $query->shouldReceive('each')->once()->with(m::on(function ($callback) use ($leaf) {
+            $callback($leaf);
 
             return $callback instanceof Closure;
         }));
@@ -355,7 +353,7 @@ class ModelQueryTest extends TestCase
 
         $model->setRawAttributes(['dn' => 'foo', 'cn' => 'bar']);
         $this->assertNull($model->deleteLeafNodes());
-        $this->assertFalse($shouldBeDeleted->first()->exists);
+        $this->assertFalse($leaf->exists);
     }
 
     public function test_destroy()


### PR DESCRIPTION
Closes #541 

This PR implements dynamically creating new connections when chunking a query.

This allows simultaneous pagination queries that contain cookies to be executed on servers that do not actually support it.