### PR TITLE
Appropriately handle maximum and minimum values of windows integer time

### DIFF
--- a/src/Models/Attributes/Timestamp.php
+++ b/src/Models/Attributes/Timestamp.php
@@ -11,6 +11,8 @@ use LdapRecord\Utilities;
 
 class Timestamp
 {
+    public const WINDOWS_INT_MAX = 9223372036854775807;
+
     /**
      * The current timestamp type.
      *
@@ -229,7 +231,7 @@ class Timestamp
             return (int) $value;
         }
 
-        if ($value == 9223372036854775807) {
+        if ($value == static::WINDOWS_INT_MAX) {
             return (int) $value;
         }
 

--- a/src/Models/Attributes/Timestamp.php
+++ b/src/Models/Attributes/Timestamp.php
@@ -114,7 +114,7 @@ class Timestamp
      */
     protected function valueIsWindowsIntegerType($value)
     {
-        return is_numeric($value) && strlen((string) $value) === 18;
+        return is_numeric($value) && in_array(strlen((string) $value), [18, 19]);
     }
 
     /**
@@ -122,7 +122,7 @@ class Timestamp
      *
      * @param mixed $value
      *
-     * @return Carbon|false
+     * @return Carbon|int|false
      *
      * @throws LdapRecordException
      */
@@ -215,16 +215,22 @@ class Timestamp
      *
      * @param int $value
      *
-     * @return DateTime|false
+     * @return DateTime|int|false
      *
      * @throws \Exception
      */
     protected function convertWindowsIntegerTimeToDateTime($value)
     {
-        // ActiveDirectory dates that contain integers may return
-        // "0" when they are not set. We will validate that here.
-        if (! $value) {
+        if (is_null($value) || $value === '') {
             return false;
+        }
+
+        if ($value == 0) {
+            return (int) $value;
+        }
+
+        if ($value == 9223372036854775807) {
+            return (int) $value;
         }
 
         return (new DateTime())->setTimestamp(

--- a/tests/Unit/Models/ActiveDirectory/UserTest.php
+++ b/tests/Unit/Models/ActiveDirectory/UserTest.php
@@ -212,6 +212,26 @@ class UserTest extends TestCase
 
         $this->assertTrue($user->isEnabled());
     }
+
+    public function test_account_expires_with_maximum()
+    {
+        $user = new User();
+
+        $max = 9223372036854775807;
+
+        $user->accountExpires = 9223372036854775807;
+
+        $this->assertSame($max, $user->accountExpires);
+    }
+
+    public function test_account_expires_with_minimum()
+    {
+        $user = new User();
+
+        $user->accountExpires = 0;
+
+        $this->assertSame(0, $user->accountExpires);
+    }
 }
 
 class UserPasswordTestStub extends User

--- a/tests/Unit/Models/ActiveDirectory/UserTest.php
+++ b/tests/Unit/Models/ActiveDirectory/UserTest.php
@@ -217,9 +217,9 @@ class UserTest extends TestCase
     {
         $user = new User();
 
-        $max = 9223372036854775807;
+        $max = Timestamp::WINDOWS_INT_MAX;
 
-        $user->accountExpires = 9223372036854775807;
+        $user->accountExpires = $max;
 
         $this->assertSame($max, $user->accountExpires);
     }

--- a/tests/Unit/Models/Attributes/TimestampTest.php
+++ b/tests/Unit/Models/Attributes/TimestampTest.php
@@ -121,7 +121,7 @@ class TimestampTest extends TestCase
     {
         $timestamp = new Timestamp('windows-int');
 
-        $max = 9223372036854775807;
+        $max = Timestamp::WINDOWS_INT_MAX;
 
         $this->assertSame($max, $timestamp->toDateTime($max));
         $this->assertSame($max, $timestamp->toDateTime((string) $max));

--- a/tests/Unit/Models/Attributes/TimestampTest.php
+++ b/tests/Unit/Models/Attributes/TimestampTest.php
@@ -116,4 +116,24 @@ class TimestampTest extends TestCase
 
         date_default_timezone_set('UTC');
     }
+
+    public function test_windows_int_type_properly_handles_maximum()
+    {
+        $timestamp = new Timestamp('windows-int');
+
+        $max = 9223372036854775807;
+
+        $this->assertSame($max, $timestamp->toDateTime($max));
+        $this->assertSame($max, $timestamp->toDateTime((string) $max));
+    }
+
+    public function test_windows_int_type_properly_handles_minimum()
+    {
+        $timestamp = new Timestamp('windows-int');
+
+        $min = 0;
+
+        $this->assertSame($min, $timestamp->toDateTime($min));
+        $this->assertSame($min, $timestamp->toDateTime((string) $min));
+    }
 }


### PR DESCRIPTION
Closes #552

This PR implements appropriate handling of Windows Integer time maximum or minimum values (`0` and `9223372036854775807`).

If a `windows-int` based cast is used on a model and the value is equal to either of the above mentioned values, then those values will be returned, instead of a `Carbon` instance.