### PR TITLE
Ensure that host is set, before finding cache key

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -774,6 +774,10 @@ class Builder
     protected function getCacheKey($query)
     {
         $host = $this->connection->getLdapConnection()->getHost();
+        if (!$host) {
+            $this->connection->connect();
+            $host = $this->connection->getLdapConnection()->getHost();
+        }
 
         $key = $host
             .$this->type

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -774,7 +774,7 @@ class Builder
     protected function getCacheKey($query)
     {
         $host = $this->connection->getLdapConnection()->getHost();
-        if (!$host) {
+        if (! $host) {
             $this->connection->connect();
             $host = $this->connection->getLdapConnection()->getHost();
         }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -773,11 +773,9 @@ class Builder
      */
     protected function getCacheKey($query)
     {
-        $host = $this->connection->getLdapConnection()->getHost();
-        if (! $host) {
-            $this->connection->connect();
-            $host = $this->connection->getLdapConnection()->getHost();
-        }
+        $host = $this->connection->run(function (LdapInterface $ldap) {
+            return $ldap->getHost();
+        });
 
         $key = $host
             .$this->type

--- a/src/Testing/LdapFake.php
+++ b/src/Testing/LdapFake.php
@@ -264,6 +264,16 @@ class LdapFake implements LdapInterface
     /**
      * @inheritdoc
      */
+    public function getHost()
+    {
+        return $this->hasExpectations('getHost')
+            ? $this->resolveExpectation('getHost')
+            : $this->host;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function setOption($option, $value)
     {
         return $this->hasExpectations('setOption')

--- a/tests/Integration/CacheTest.php
+++ b/tests/Integration/CacheTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace LdapRecord\Tests\Integration;
+
+use Carbon\Carbon;
+use LdapRecord\Connection;
+use LdapRecord\Container;
+use LdapRecord\Models\OpenLDAP\OrganizationalUnit;
+use LdapRecord\Query\ArrayCacheStore;
+use LdapRecord\Tests\Integration\Fixtures\User;
+use Psr\SimpleCache\CacheInterface;
+
+class CacheTest extends TestCase
+{
+    /** @var OrganizationalUnit */
+    protected $ou;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Container::addConnection($this->makeConnection());
+
+        $this->ou = OrganizationalUnit::query()->where('ou', 'User Test OU')->firstOr(function () {
+            return OrganizationalUnit::create(['ou' => 'User Test OU']);
+        });
+
+        $this->ou->deleteLeafNodes();
+    }
+
+    protected function resetConnection(array $params = [], CacheInterface $cache = null): Connection
+    {
+        Container::reset();
+
+        $connection = parent::makeConnection($params);
+        if ($cache) {
+            $connection->setCache($cache);
+        }
+
+        Container::addConnection($connection);
+
+        return $connection;
+    }
+
+    protected function tearDown(): void
+    {
+        $this->ou->delete(true);
+
+        Container::reset();
+
+        parent::tearDown();
+    }
+
+    protected function createUser(string $cn): User
+    {
+        $user = (new User())
+            ->inside($this->ou)
+            ->fill(array_merge([
+                'uid' => 'u'.$cn,
+                'cn' => $cn,
+                'sn' => 'Baz',
+                'givenName' => $cn,
+                'uidNumber' => 1000 + ord($cn),
+                'gidNumber' => 1000 + ord($cn),
+                'homeDirectory' => '/'.strtolower($cn),
+            ]));
+
+        $user->save();
+
+        return $user;
+    }
+
+    protected function listUserCNsUsingCache(int $ttl = 30): array
+    {
+        $cache = Carbon::now()->addSecond($ttl);
+
+        $result = [];
+        foreach (User::cache($cache)->get() as $user) {
+            $result[] = $user->cn[0];
+        }
+        sort($result);
+
+        return $result;
+    }
+
+    public function test_that_results_are_fetched_from_cache()
+    {
+        $cache = new ArrayCacheStore();
+        $c = $this->resetConnection([], $cache);
+
+        $this->assertEquals([], $this->listUserCNsUsingCache());
+        $user = $this->createUser('foo');
+
+        $this->assertEquals([], $this->listUserCNsUsingCache());
+    }
+
+    public function test_that_results_are_fetched_from_cache2()
+    {
+        $cache = new ArrayCacheStore();
+        $c = $this->resetConnection([], $cache);
+
+        $user = $this->createUser('foo');
+        $this->assertEquals(['foo'], $this->listUserCNsUsingCache());
+        $user = $this->createUser('bar');
+
+        $this->assertEquals(['foo'], $this->listUserCNsUsingCache());
+    }
+
+    public function test_that_results_expire_from_cache()
+    {
+        $cache = new ArrayCacheStore();
+        $this->resetConnection([], $cache);
+
+        $user = $this->createUser('foo');
+        $this->assertEquals(['foo'], $this->listUserCNsUsingCache(1));
+        $user = $this->createUser('bar');
+
+        sleep(2);
+
+        $this->assertEquals(['bar', 'foo'], $this->listUserCNsUsingCache());
+    }
+
+    public function test_that_results_stay_in_cache_even_if_connection_is_reset()
+    {
+        $cache = new ArrayCacheStore();
+        $this->resetConnection([], $cache);
+
+        $user = $this->createUser('foo');
+        $this->assertEquals(['foo'], $this->listUserCNsUsingCache());
+        $user = $this->createUser('bar');
+
+        $this->resetConnection([], $cache);
+
+        $this->assertEquals(['foo'], $this->listUserCNsUsingCache());
+    }
+
+    public function test_that_results_are_not_reused_if_hostname_changes()
+    {
+        $cache = new ArrayCacheStore();
+        $this->resetConnection([], $cache);
+
+        $user = $this->createUser('foo');
+        $this->assertEquals(['foo'], $this->listUserCNsUsingCache());
+        $user = $this->createUser('bar');
+
+        $this->resetConnection(['hosts' => ['127.0.0.1']], $cache);
+
+        $this->assertEquals(['bar', 'foo'], $this->listUserCNsUsingCache());
+    }
+}


### PR DESCRIPTION
The LDAP host is part of the cache key, but the host is only set after the first connection. This patch ensures that host is always set before the finding the cache key.

Without this patch you'll get wrong results if your site/script as the first thing tries to do the same query on multiple connections. Further, you are not caching results as expected. Consider the following "script": 
1. `Entry::on('a')->cache(...)->where('k1','=','1')->get();` # new connection, saves result with host=`null`
2. `Entry::on('b')->cache(...)->where('k1','=','1')->get();` # you get the (wrong) results from connection a
3. `Entry::on('c')->cache(...)->where('k1,'=','1')->get();` # you get the (wrong) results from connection a
4. `Entry::on('a')->cache(...)->where('k1','=','1')->get();` # not using cache from step 1, as the cache key is now different.
5. `Entry::on('a')->cache(...)->where('k2','=','1')->get();` # saves result with host value set

The 2nd time you run the above the above, Step 4 uses the results from Step 1. Step 5 cannot use the cache from before (as host now is null), and retrieves a new result (and saves the result with host='null').

The 3rd time, all of the above steps use the cache. Step 2 and 3 still has wrong results.