### PR TITLE
Case insensitive DN comparison

### DIFF
--- a/src/Models/Collection.php
+++ b/src/Models/Collection.php
@@ -94,8 +94,8 @@ class Collection extends QueryCollection
     {
         if (is_string($model)) {
             return $this->isValidDn($model)
-                ? $related->getDn() == $model
-                : $related->getName() == $model;
+                ? strcasecmp($related->getDn(), $model) === 0
+                : strcasecmp($related->getName(), $model) === 0;
         }
 
         return $related->is($model);

--- a/tests/Unit/Models/ModelRelationTest.php
+++ b/tests/Unit/Models/ModelRelationTest.php
@@ -129,11 +129,13 @@ class ModelRelationTest extends TestCase
         $this->assertTrue($relation->exists($related->newCollection([$related])));
         $this->assertTrue($relation->exists('foo'));
         $this->assertTrue($relation->exists('cn=foo,dc=local,dc=com'));
+        $this->assertTrue($relation->exists('CN=foo,DC=local,DC=com'));
 
         $this->assertFalse($relation->exists(null));
         $this->assertFalse($relation->exists($unrelated->newCollection([$unrelated])));
         $this->assertFalse($relation->exists([$related, $unrelated]));
         $this->assertFalse($relation->exists(['cn=foo,dc=local,dc=com', 'cn=bar,dc=local,dc=com']));
+        $this->assertFalse($relation->exists(['CN=foo,DC=local,DC=com', 'CN=bar,DC=local,DC=com']));
         $this->assertFalse($relation->exists('bar'));
     }
 


### PR DESCRIPTION
I noticed while I was making an authentication rule, that the validation would fail, even though I was sure that the DN was correctly given.

Turns out that providing a string wouldn't work while providing the same string within `Group::findOrFail` would work if the DN provided by the LDAP server has a different case, like `cn=foo,dc=local,dc=com`.

Works:
```php
return $this->user->groups()->exists(
    Group::findOrFail('CN=foo,DC=local,DC=com')
);
```

Doesn't work:
```php
return $this->user->groups()->exists(
    'CN=foo,DC=local,DC=com'
);
```