### PR TITLE
Fix RDN comparison in model rename function

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -1166,6 +1166,13 @@ abstract class Model implements ArrayAccess, Arrayable, JsonSerializable
             $newParentDn = $this->getParentDn($this->dn);
         }
 
+        // If the RDN we have been given is empty when parsed, we must
+        // have been given a string, with no attribute. In this case,
+        // we will create a new RDN using the current DN's head.
+        if ($this->newDn($rdn)->isEmpty()) {
+            $rdn = $this->getUpdateableRdn($rdn);
+        }
+
         // If the RDN and the new parent DN are the same as the current,
         // we will simply return here to prevent a rename operation
         // being sent, which would fail anyway in such case.
@@ -1174,13 +1181,6 @@ abstract class Model implements ArrayAccess, Arrayable, JsonSerializable
          && $newParentDn === $this->getParentDn()
         ) {
             return;
-        }
-
-        // If the RDN we have been given is empty when parsed, we must
-        // have been given a string, with no attribute. In this case,
-        // we will create a new RDN using the current DN's head.
-        if ($this->newDn($rdn)->isEmpty()) {
-            $rdn = $this->getUpdateableRdn($rdn);
         }
 
         $this->dispatch('renaming', [$rdn, $newParentDn]);


### PR DESCRIPTION
This commit fixes the way RDN is compared when renaming an object, in that if the RDN attribute is ommited it will be appended to the string before comparing it with the Models RDN.

e.g. if supplied with an OU named 'TestOU' and we called `$TestOU->rename('TestOU');` by the time the comparison is run this is the value of `$rdn` and `$this->getRdn()` being compared:
![Screenshot 2023-06-20 222044](https://github.com/DirectoryTree/LdapRecord/assets/2669153/94f1a9d1-3f0f-4017-a734-c9838c7e1a22)

By placing the RDN fixer code above the RDN check code this solves the issue of a non-complete RDN causing an unnessicary update on the LDAP server.