### PR TITLE
Adds Stringable interface to all classes containing __toString() method.

### DIFF
--- a/src/Models/Attributes/AccountControl.php
+++ b/src/Models/Attributes/AccountControl.php
@@ -3,8 +3,9 @@
 namespace LdapRecord\Models\Attributes;
 
 use ReflectionClass;
+use Stringable;
 
-class AccountControl
+class AccountControl implements Stringable
 {
     public const SCRIPT = 1;
 

--- a/src/Models/Attributes/DistinguishedName.php
+++ b/src/Models/Attributes/DistinguishedName.php
@@ -4,8 +4,9 @@ namespace LdapRecord\Models\Attributes;
 
 use LdapRecord\EscapesValues;
 use LdapRecord\Support\Arr;
+use Stringable;
 
-class DistinguishedName
+class DistinguishedName implements Stringable
 {
     use EscapesValues;
 

--- a/src/Models/Attributes/DistinguishedNameBuilder.php
+++ b/src/Models/Attributes/DistinguishedNameBuilder.php
@@ -4,8 +4,9 @@ namespace LdapRecord\Models\Attributes;
 
 use LdapRecord\EscapesValues;
 use LdapRecord\Support\Arr;
+use Stringable;
 
-class DistinguishedNameBuilder
+class DistinguishedNameBuilder implements Stringable
 {
     use EscapesValues;
 

--- a/src/Models/Attributes/EscapedValue.php
+++ b/src/Models/Attributes/EscapedValue.php
@@ -2,7 +2,9 @@
 
 namespace LdapRecord\Models\Attributes;
 
-class EscapedValue
+use Stringable;
+
+class EscapedValue implements Stringable
 {
     /**
      * The value to be escaped.

--- a/src/Models/Attributes/Guid.php
+++ b/src/Models/Attributes/Guid.php
@@ -3,8 +3,9 @@
 namespace LdapRecord\Models\Attributes;
 
 use InvalidArgumentException;
+use Stringable;
 
-class Guid
+class Guid implements Stringable
 {
     /**
      * The string GUID value.

--- a/src/Models/Attributes/Sid.php
+++ b/src/Models/Attributes/Sid.php
@@ -3,8 +3,9 @@
 namespace LdapRecord\Models\Attributes;
 
 use InvalidArgumentException;
+use Stringable;
 
-class Sid
+class Sid implements Stringable
 {
     /**
      * The string SID value.

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -13,10 +13,11 @@ use LdapRecord\Models\Attributes\DistinguishedName;
 use LdapRecord\Models\Attributes\Guid;
 use LdapRecord\Query\Model\Builder;
 use LdapRecord\Support\Arr;
+use Stringable;
 use UnexpectedValueException;
 
 /** @mixin Builder */
-abstract class Model implements ArrayAccess, Arrayable, JsonSerializable
+abstract class Model implements ArrayAccess, Arrayable, JsonSerializable, Stringable
 {
     use EscapesValues;
     use Concerns\HasEvents;


### PR DESCRIPTION
Since this project now requires a minimum PHP version of 8.1, PHP 8.0 introduced a new interface called [Stringable](https://www.php.net/manual/en/class.stringable.php) which we are able to explicitly implement.

As the excerpt from the linked docs states above, although any class implementing `__toString()` will automatically gain the Stringable interface, it can and **should** be declared explicitly (presumably for future versions of PHP, and IDE help etc).

This PR implements Stringable to all classes implementing the `__toString()` method.