### PR TITLE
Bug 634 - Relation::setModelResolver in AppServiceProvider no longer works in v3

### DIFF
--- a/src/Models/Relations/Relation.php
+++ b/src/Models/Relations/Relation.php
@@ -66,10 +66,6 @@ abstract class Relation
         $this->relationKey = $relationKey;
         $this->foreignKey = $foreignKey;
 
-        static::$modelResolver = function (array $modelObjectClasses, array $relationMap) {
-            return array_search($modelObjectClasses, $relationMap);
-        };
-
         $this->initRelation();
     }
 
@@ -333,12 +329,11 @@ abstract class Relation
             $model->getObjectClasses()
         );
 
-        return call_user_func(
-            static::$modelResolver,
-            $modelObjectClasses,
-            $relationMap,
-            $model,
-        );
+        $resolver = static::$modelResolver ?? function (array $modelObjectClasses, array $relationMap) {
+            return array_search($modelObjectClasses, $relationMap);
+        };
+
+        return call_user_func($resolver, $modelObjectClasses, $relationMap, $model);
     }
 
     /**

--- a/tests/Unit/Models/ModelRelationTest.php
+++ b/tests/Unit/Models/ModelRelationTest.php
@@ -268,7 +268,7 @@ class ModelRelationTest extends TestCase
             return array_search($modelObjectClasses, $relationMap);
         });
 
-        $this->assertInstanceOf(RelatedModelTestStub::class, $relation->first());
+        $relation->first();
     }
 }
 

--- a/tests/Unit/Models/ModelRelationTest.php
+++ b/tests/Unit/Models/ModelRelationTest.php
@@ -249,6 +249,27 @@ class ModelRelationTest extends TestCase
 
         $this->assertInstanceOf(RelatedModelTestStub::class, $relation->first());
     }
+
+    public function test_related_models_can_be_resolved_with_resolver_callback()
+    {
+        $relation = (new ModelRelationTestStub())->relation();
+
+        $related = new Entry();
+
+        $related->objectclass = ['bar', 'foo'];
+        $related->setDn('cn=foo,dc=local,dc=com');
+
+        $relation->setResults([$related]);
+
+        Relation::resolveModelsUsing(function (array $modelObjectClasses, array $relationMap) use ($related) {
+            $this->assertEquals($related->getObjectClasses(), $modelObjectClasses);
+            $this->assertEquals([RelatedModelTestStub::class => $related->getObjectClasses()], $relationMap);
+
+            return array_search($modelObjectClasses, $relationMap);
+        });
+
+        $this->assertInstanceOf(RelatedModelTestStub::class, $relation->first());
+    }
 }
 
 class RelationTestStub extends Relation


### PR DESCRIPTION
Closes #634 