### PR TITLE
Add "changes" API to models

### DIFF
--- a/src/Models/Concerns/HasAttributes.php
+++ b/src/Models/Concerns/HasAttributes.php
@@ -21,6 +21,11 @@ trait HasAttributes
     protected array $original = [];
 
     /**
+     * The models changed attributes.
+     */
+    protected array $changes = [];
+
+    /**
      * The models attributes.
      */
     protected array $attributes = [];
@@ -253,6 +258,16 @@ trait HasAttributes
     public function syncOriginal(): static
     {
         $this->original = $this->attributes;
+
+        return $this;
+    }
+
+    /**
+     * Sync the changed attributes.
+     */
+    public function syncChanges(): static
+    {
+        $this->changes = $this->getDirty();
 
         return $this;
     }
@@ -870,11 +885,55 @@ trait HasAttributes
     }
 
     /**
+     * Get the attributes that have been changed since the model was last saved.
+     */
+    public function getChanges(): array
+    {
+        return $this->changes;
+    }
+
+    /**
      * Determine if the given attribute is dirty.
      */
     public function isDirty(string $key): bool
     {
         return ! $this->originalIsEquivalent($key);
+    }
+
+    /**
+     * Determine if given attribute has remained the same.
+     */
+    public function isClean(string $key): bool
+    {
+        return ! $this->isDirty($key);
+    }
+
+    /**
+     * Discard attribute changes and reset the attributes to their original state.
+     */
+    public function discardChanges(): static
+    {
+        [$this->attributes, $this->changes] = [$this->original, []];
+
+        return $this;
+    }
+
+    /**
+     * Determine if the model or any of the given attribute(s) were changed when the model was last saved.
+     */
+    public function wasChanged(array|string $attributes = null): bool
+    {
+        if (empty($attributes)) {
+            return count($this->changes) > 0;
+        }
+
+        foreach ((array) $attributes as $attribute) {
+            if (array_key_exists($attribute, $this->changes)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -914,6 +914,8 @@ abstract class Model implements ArrayAccess, Arrayable, JsonSerializable, String
 
         $this->dispatch('updated');
 
+        $this->syncChanges();
+
         $this->syncOriginal();
     }
 

--- a/tests/Unit/Models/ModelTest.php
+++ b/tests/Unit/Models/ModelTest.php
@@ -349,6 +349,9 @@ class ModelTest extends TestCase
         $this->assertTrue($model->wasChanged('baz'));
         $this->assertTrue($model->wasChanged(['bar', 'baz']));
 
+        $this->assertTrue($model->isClean('foo'));
+        $this->assertFalse($model->isClean('bar'));
+
         $this->assertEquals([
             'bar' => [20],
             'baz' => [30],

--- a/tests/Unit/Models/ModelTest.php
+++ b/tests/Unit/Models/ModelTest.php
@@ -330,6 +330,36 @@ class ModelTest extends TestCase
         ], $model->getDirty());
     }
 
+    public function test_changed_attributes()
+    {
+        $model = new Entry(['foo' => 1, 'bar' => 2]);
+        $model->syncOriginal();
+        $model->foo = 1;
+        $model->bar = 20;
+        $model->baz = 30;
+
+        $model->syncChanges();
+
+        $this->assertFalse($model->wasChanged('foo'));
+        $this->assertFalse($model->wasChanged(['foo']));
+
+        $this->assertTrue($model->wasChanged());
+        $this->assertTrue($model->wasChanged([]));
+        $this->assertTrue($model->wasChanged('bar'));
+        $this->assertTrue($model->wasChanged('baz'));
+        $this->assertTrue($model->wasChanged(['bar', 'baz']));
+
+        $this->assertEquals([
+            'bar' => [20],
+            'baz' => [30],
+        ], $model->getChanges());
+
+        $model->discardChanges();
+
+        $this->assertEmpty($model->getChanges());
+        $this->assertEquals(['foo' => [1], 'bar' => [2]], $model->getAttributes());
+    }
+
     public function test_reset_integer_is_kept_in_tact_when_batch_modifications_are_generated()
     {
         $model = new Entry();


### PR DESCRIPTION
This PR implements the ability to retrieve changes on a model after an update has been performed.

This is really handy to be able to retrieve all of the changed attributes of a model, _after_ an update:

```php
use LdapRecord\Models\Entry;

$model = Entry::find('cn=jdoe,dc=local,dc=com');

$model->mail = 'foo@email.com';

$model->save();

$model->wasChanged(); // true

$model->wasChanged('mail'); // true

$model->wasChanged('invalid'); // false

$model->wasChanged(['mail', 'invalid']); // true

$model->getChanges(); // ['mail' => ['foo@email.com']]
```