### PR TITLE
Replace deprecated utf8_encode

### DIFF
--- a/src/Models/Concerns/HasAttributes.php
+++ b/src/Models/Concerns/HasAttributes.php
@@ -212,7 +212,7 @@ trait HasAttributes
             return $value;
         }
 
-        return utf8_encode($value);
+        return mb_convert_encoding($value, 'UTF-8', 'ISO-8859-1');
     }
 
     /**


### PR DESCRIPTION
As described here - https://www.php.net/manual/en/function.utf8-encode.php - utf8_encode is deprecated in PHP 8.2