### PR TITLE
Bug 688 - `getAuthIdentifier` for OpenLDAP users returns incorrect value

### DIFF
--- a/src/Models/ActiveDirectory/User.php
+++ b/src/Models/ActiveDirectory/User.php
@@ -68,6 +68,14 @@ class User extends Entry implements Authenticatable
     }
 
     /**
+     * Get the unique identifier for the user.
+     */
+    public function getAuthIdentifier(): ?string
+    {
+        return $this->getConvertedGuid();
+    }
+
+    /**
      * The groups relationship.
      *
      * Retrieves groups that the user is apart of.

--- a/src/Models/Concerns/CanAuthenticate.php
+++ b/src/Models/Concerns/CanAuthenticate.php
@@ -14,14 +14,6 @@ trait CanAuthenticate
     }
 
     /**
-     * Get the unique identifier for the user.
-     */
-    public function getAuthIdentifier(): ?string
-    {
-        return $this->getConvertedGuid();
-    }
-
-    /**
      * Get the password for the user.
      */
     public function getAuthPassword(): string

--- a/src/Models/OpenLDAP/User.php
+++ b/src/Models/OpenLDAP/User.php
@@ -33,6 +33,14 @@ class User extends Entry implements Authenticatable
     ];
 
     /**
+     * Get the unique identifier for the user.
+     */
+    public function getAuthIdentifier(): ?string
+    {
+        return $this->getFirstAttribute($this->guidKey);
+    }
+
+    /**
      * The groups relationship.
      */
     public function groups(): HasMany

--- a/tests/Unit/Models/ActiveDirectory/UserTest.php
+++ b/tests/Unit/Models/ActiveDirectory/UserTest.php
@@ -249,6 +249,15 @@ class UserTest extends TestCase
 
         $this->assertSame(0, $user->accountExpires);
     }
+
+    public function test_correct_auth_identifier_is_returned()
+    {
+        $guid = '270db4d0-249d-46a7-9cc5-eb695d9af9ac';
+
+        $user = new User(['objectguid' => $guid]);
+
+        $this->assertEquals($guid, $user->getAuthIdentifier());
+    }
 }
 
 class UserPasswordTestStub extends User

--- a/tests/Unit/Models/OpenLDAP/UserTest.php
+++ b/tests/Unit/Models/OpenLDAP/UserTest.php
@@ -74,6 +74,15 @@ class UserTest extends TestCase
         [, $newAlgo] = Password::getHashMethodAndAlgo($new['values'][0]);
         $this->assertEquals(Password::CRYPT_SALT_TYPE_SHA512, $newAlgo);
     }
+
+    public function test_correct_auth_identifier_is_returned()
+    {
+        $entryUuid = 'foo';
+
+        $user = new User(['entryuuid' => $entryUuid]);
+
+        $this->assertEquals($entryUuid, $user->getAuthIdentifier());
+    }
 }
 
 class OpenLDAPUserTestStub extends User


### PR DESCRIPTION
Closes #688 