### PR TITLE
Add `BindException` to `Failed` event for additional debugging information

### DIFF
--- a/src/Auth/Events/Failed.php
+++ b/src/Auth/Events/Failed.php
@@ -23,7 +23,7 @@ class Failed extends Event
     }
 
     /**
-     * Get the exception that was thrown.
+     * Get the exception that was thrown during the bind attempt.
      */
     public function getException(): Exception
     {

--- a/src/Auth/Events/Failed.php
+++ b/src/Auth/Events/Failed.php
@@ -2,7 +2,31 @@
 
 namespace LdapRecord\Auth\Events;
 
+use Exception;
+use LdapRecord\LdapInterface;
+
 class Failed extends Event
 {
-    //
+    /**
+     * The exception that was thrown during the bind attempt.
+     */
+    protected Exception $exception;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(LdapInterface $connection, ?string $username, ?string $password, Exception $exception)
+    {
+        parent::__construct($connection, $username, $password);
+
+        $this->exception = $exception;
+    }
+
+    /**
+     * Get the exception that was thrown.
+     */
+    public function getException(): Exception
+    {
+        return $this->exception;
+    }
 }

--- a/src/Auth/Guard.php
+++ b/src/Auth/Guard.php
@@ -91,9 +91,11 @@ class Guard
 
             $this->fireAuthEvent('bound', $username, $password);
         } catch (Exception $e) {
-            $this->fireAuthEvent('failed', $username, $password);
+            $exception = BindException::withDetailedError($e, $this->connection->getDetailedError());
 
-            throw BindException::withDetailedError($e, $this->connection->getDetailedError());
+            $this->fireAuthEvent('failed', $username, $password, $exception);
+
+            throw $exception;
         }
     }
 
@@ -147,12 +149,12 @@ class Guard
     /**
      * Fire an authentication event.
      */
-    protected function fireAuthEvent(string $name, ?string $username = null, ?string $password = null): void
+    protected function fireAuthEvent(string $name, ?string $username = null, ?string $password = null, ...$args): void
     {
         if (isset($this->events)) {
             $event = implode('\\', [Events::class, ucfirst($name)]);
 
-            $this->events->fire(new $event($this->connection, $username, $password));
+            $this->events->fire(new $event($this->connection, $username, $password, ...$args));
         }
     }
 }

--- a/tests/Unit/Auth/GuardTest.php
+++ b/tests/Unit/Auth/GuardTest.php
@@ -104,27 +104,6 @@ class GuardTest extends TestCase
 
     public function test_binding_events_are_fired_during_bind()
     {
-        $events = m::mock(Dispatcher::class);
-        $events->shouldReceive('fire')->once()->with(m::on(fn ($event) => $event instanceof Binding));
-        $events->shouldReceive('fire')->once()->with(m::on(
-            fn ($event) => $event instanceof Failed && $event->getException() instanceof BindException)
-        );
-
-        $this->expectException(BindException::class);
-
-        $ldap = (new LdapFake)->expect(
-            LdapFake::operation('bind')->once()->with('johndoe', 'secret')->andThrow(new Exception('foo'))
-        );
-
-        $guard = new Guard($ldap, new DomainConfiguration());
-
-        $guard->setDispatcher($events);
-
-        $guard->bind('johndoe', 'secret');
-    }
-
-    public function test_bind_failed_event_includes_exception_thrown()
-    {
         $events = new Dispatcher();
 
         $events->listen(Bound::class, function (Bound $event) use (&$firedBound) {
@@ -136,6 +115,27 @@ class GuardTest extends TestCase
 
         $ldap = (new LdapFake)->expect(
             LdapFake::operation('bind')->once()->with('johndoe', 'secret')->andReturnResponse()
+        );
+
+        $guard = new Guard($ldap, new DomainConfiguration());
+
+        $guard->setDispatcher($events);
+
+        $guard->bind('johndoe', 'secret');
+    }
+
+    public function test_bind_failed_event_includes_exception_thrown()
+    {
+        $events = m::mock(Dispatcher::class);
+        $events->shouldReceive('fire')->once()->with(m::on(fn ($event) => $event instanceof Binding));
+        $events->shouldReceive('fire')->once()->with(m::on(
+            fn ($event) => $event instanceof Failed && $event->getException() instanceof BindException)
+        );
+
+        $this->expectException(BindException::class);
+
+        $ldap = (new LdapFake)->expect(
+            LdapFake::operation('bind')->once()->with('johndoe', 'secret')->andThrow(new Exception('foo'))
         );
 
         $guard = new Guard($ldap, new DomainConfiguration());

--- a/tests/Unit/Log/EventLoggerTest.php
+++ b/tests/Unit/Log/EventLoggerTest.php
@@ -2,6 +2,7 @@
 
 namespace LdapRecord\Tests\Unit\Log;
 
+use Exception;
 use LdapRecord\Auth\Events\Bound;
 use LdapRecord\Auth\Events\Failed;
 use LdapRecord\Events\Logger;
@@ -35,11 +36,11 @@ class EventLoggerTest extends TestCase
 
     public function test_failed_auth_event_reports_result()
     {
-        $ldap = (new LdapFake())->shouldReturnError('Invalid Credentials');
+        $ldap = (new LdapFake)->shouldReturnError('Invalid Credentials');
 
         $ldap->connect('localhost');
 
-        $event = new Failed($ldap, 'jdoe@acme.org', 'super-secret');
+        $event = new Failed($ldap, 'jdoe@acme.org', 'super-secret', new Exception());
 
         $logger = m::mock(LoggerInterface::class);
 
@@ -54,7 +55,7 @@ class EventLoggerTest extends TestCase
 
     public function test_queries_are_logged()
     {
-        $ldap = (new LdapFake())->expect(['search' => []]);
+        $ldap = (new LdapFake)->expect(['search' => []]);
 
         $conn = new ConnectionFake([
             'base_dn' => 'dc=local,dc=com',


### PR DESCRIPTION
Related https://github.com/DirectoryTree/LdapRecord/discussions/708

This PR adds the `BindException` to the `Failed` event to provide additional debugging functionality to developers listening to the event.