### PR TITLE
Bug 707 - Attribute casting seem to work only in one direction

### DIFF
--- a/src/Models/Concerns/HasAttributes.php
+++ b/src/Models/Concerns/HasAttributes.php
@@ -690,12 +690,14 @@ trait HasAttributes
 
         if ($this->hasSetMutator($key)) {
             return $this->setMutatedAttributeValue($key, $value);
-        } elseif (
+        }
+
+        if (
             $value &&
             $this->isDateAttribute($key) &&
             ! $this->valueIsResetInteger($value)
         ) {
-            $value = $this->fromDateTime($value, $this->getDates()[$key]);
+            $value = (string) $this->fromDateTime($value, $this->getDates()[$key]);
         }
 
         if ($this->isJsonCastable($key) && ! is_null($value)) {

--- a/tests/Unit/Models/ModelAttributeCastTest.php
+++ b/tests/Unit/Models/ModelAttributeCastTest.php
@@ -10,89 +10,125 @@ class ModelAttributeCastTest extends TestCase
 {
     public function test_boolean_attributes_are_casted()
     {
-        $model = (new ModelCastStub())->setRawAttributes(['boolAttribute' => ['TRUE']]);
+        $model = (new ModelCastStub)->setRawAttributes(['boolAttribute' => ['TRUE']]);
         $this->assertTrue($model->boolAttribute);
 
-        $model = (new ModelCastStub())->setRawAttributes(['boolAttribute' => ['FALSE']]);
+        $model = (new ModelCastStub)->setRawAttributes(['boolAttribute' => ['FALSE']]);
         $this->assertFalse($model->boolAttribute);
 
-        $model = (new ModelCastStub())->setRawAttributes(['booleanAttribute' => ['FALSE']]);
+        $model = (new ModelCastStub)->setRawAttributes(['booleanAttribute' => ['FALSE']]);
         $this->assertFalse($model->booleanAttribute);
 
-        $model = (new ModelCastStub())->setRawAttributes(['booleanAttribute' => ['FALSE']]);
+        $model = (new ModelCastStub)->setRawAttributes(['booleanAttribute' => ['FALSE']]);
         $this->assertFalse($model->booleanAttribute);
+
+        // Reverse casting
+
+        $model->booleanAttribute = true;
+        $this->assertTrue($model->booleanAttribute);
+        $this->assertEquals($model->getRawAttribute('booleanAttribute'), ['TRUE']);
 
         // Casing differences
 
-        $model = (new ModelCastStub())->setRawAttributes(['boolAttribute' => ['true']]);
+        $model = (new ModelCastStub)->setRawAttributes(['boolAttribute' => ['true']]);
         $this->assertTrue($model->boolAttribute);
 
-        $model = (new ModelCastStub())->setRawAttributes(['boolAttribute' => ['false']]);
+        $model = (new ModelCastStub)->setRawAttributes(['boolAttribute' => ['false']]);
         $this->assertFalse($model->boolAttribute);
 
         // Variable differences
 
-        $model = (new ModelCastStub())->setRawAttributes(['boolAttribute' => ['invalid']]);
+        $model = (new ModelCastStub)->setRawAttributes(['boolAttribute' => ['invalid']]);
         $this->assertTrue($model->boolAttribute);
 
-        $model = (new ModelCastStub())->setRawAttributes(['boolAttribute' => ['']]);
+        $model = (new ModelCastStub)->setRawAttributes(['boolAttribute' => ['']]);
         $this->assertFalse($model->boolAttribute);
 
-        $model = (new ModelCastStub())->setRawAttributes(['boolAttribute' => []]);
+        $model = (new ModelCastStub)->setRawAttributes(['boolAttribute' => []]);
         $this->assertNull($model->boolAttribute);
 
-        $model = (new ModelCastStub());
+        $model = (new ModelCastStub);
         $this->assertNull($model->boolAttribute);
     }
 
     public function test_float_attributes_are_casted()
     {
-        $model = (new ModelCastStub())->setRawAttributes(['floatAttribute' => ['12345.6789']]);
+        $model = (new ModelCastStub)->setRawAttributes(['floatAttribute' => ['12345.6789']]);
 
         $this->assertIsFloat($value = $model->floatAttribute);
         $this->assertEquals(12345.6789, $value);
+
+        // Reverse casting
+
+        $model->floatAttribute = 12345.6789;
+        $this->assertIsFloat($model->floatAttribute);
+        $this->assertEquals($model->getRawAttribute('floatAttribute'), ['12345.6789']);
     }
 
     public function test_double_attributes_are_casted()
     {
-        $model = (new ModelCastStub())->setRawAttributes(['doubleAttribute' => ['1234.567']]);
+        $model = (new ModelCastStub)->setRawAttributes(['doubleAttribute' => ['1234.567']]);
 
         $this->assertIsFloat($value = $model->doubleAttribute);
         $this->assertEquals(1234.567, $value);
+
+        // Reverse casting
+
+        $model->doubleAttribute = 1234.567;
+        $this->assertIsFloat($model->doubleAttribute);
+        $this->assertEquals($model->getRawAttribute('doubleAttribute'), ['1234.567']);
     }
 
     public function test_object_attributes_are_casted()
     {
-        $model = (new ModelCastStub())->setRawAttributes(['objectAttribute' => ['{"foo": 1, "bar": "two"}']]);
+        $model = (new ModelCastStub)->setRawAttributes(['objectAttribute' => ['{"foo": 1, "bar": "two"}']]);
 
         $this->assertIsObject($value = $model->objectAttribute);
 
-        $object = (new \stdClass());
+        $object = (new \stdClass);
         $object->foo = 1;
         $object->bar = 'two';
 
         $this->assertEquals($object, $value);
+
+        // Reverse casting
+
+        $model->objectAttribute = $object;
+        $this->assertIsObject($model->objectAttribute);
+        $this->assertEquals($model->getRawAttribute('objectAttribute'), ['{"foo":1,"bar":"two"}']);
     }
 
     public function test_json_attributes_are_casted()
     {
-        $model = (new ModelCastStub())->setRawAttributes(['jsonAttribute' => ['{"foo": 1, "bar": "two"}']]);
+        $model = (new ModelCastStub)->setRawAttributes(['jsonAttribute' => ['{"foo": 1, "bar": "two"}']]);
 
         $this->assertEquals(['foo' => 1, 'bar' => 'two'], $model->jsonAttribute);
+
+        // Reverse casting
+
+        $model->jsonAttribute = ['foo' => 1, 'bar' => 'two'];
+        $this->assertEquals(['foo' => 1, 'bar' => 'two'], $model->jsonAttribute);
+        $this->assertEquals($model->getRawAttribute('jsonAttribute'), ['{"foo":1,"bar":"two"}']);
     }
 
     public function test_collection_attributes_are_casted()
     {
-        $model = (new ModelCastStub())->setRawAttributes(['collectionAttribute' => ['foo' => 1, 'bar' => 'two']]);
+        $model = (new ModelCastStub)->setRawAttributes(['collectionAttribute' => ['foo' => 1, 'bar' => 'two']]);
 
         $this->assertInstanceOf(Collection::class, $collection = $model->collectionAttribute);
 
         $this->assertEquals(['foo' => 1, 'bar' => 'two'], $collection->toArray());
+
+        // Reverse casting
+
+        $model->collectionAttribute = new Collection(['foo' => 1, 'bar' => 'two']);
+        $this->assertInstanceOf(Collection::class, $model->collectionAttribute);
+        $this->assertEquals($model->getRawAttribute('collectionAttribute'), ['{"foo":1,"bar":"two"}']);
     }
 
     public function test_integer_attributes_are_casted()
     {
-        $model = (new ModelCastStub())->setRawAttributes([
+        $model = (new ModelCastStub)->setRawAttributes([
             'intAttribute' => ['1234.5678'],
             'integerAttribute' => ['1234.5678'],
         ]);
@@ -102,36 +138,63 @@ class ModelAttributeCastTest extends TestCase
 
         $this->assertEquals(1234, $model->intAttribute);
         $this->assertEquals(1234, $model->integerAttribute);
+
+        // Reverse casting
+
+        $model->intAttribute = 1234;
+        $this->assertEquals(1234, $model->intAttribute);
+        $this->assertEquals($model->getRawAttribute('intAttribute'), ['1234']);
     }
 
     public function test_decimal_attributes_are_casted()
     {
-        $model = (new ModelCastStub())->setRawAttributes(['decimalAttribute' => ['1234.5678']]);
+        $model = (new ModelCastStub)->setRawAttributes(['decimalAttribute' => ['1234.5678']]);
 
         $this->assertIsString($value = $model->decimalAttribute);
 
         $this->assertEquals(1234.57, $value);
+
+        // Reverse casting
+
+        $model->decimalAttribute = 1234.57;
+        $this->assertIsString($model->decimalAttribute);
+        $this->assertEquals($model->getRawAttribute('decimalAttribute'), ['1234.57']);
     }
 
     public function test_ldap_datetime_attributes_are_casted()
     {
-        $model = (new ModelCastStub())->setRawAttributes(['ldapDateTime' => ['20201002021244Z']]);
+        $model = (new ModelCastStub)->setRawAttributes(['ldapDateTime' => ['20201002021244Z']]);
 
         $this->assertEquals('Fri Oct 02 2020 02:12:44 GMT+0000', $model->ldapDateTime->toString());
+
+        // Reverse casting
+
+        $model->ldapDateTime = new \DateTime('2020-10-02 02:12:44');
+        $this->assertEquals($model->getRawAttribute('ldapDateTime'), ['20201002021244Z']);
     }
 
     public function test_windows_datetime_attributes_are_casted()
     {
-        $model = (new ModelCastStub())->setRawAttributes(['windowsDateTime' => ['20201002021618.0Z']]);
+        $model = (new ModelCastStub)->setRawAttributes(['windowsDateTime' => ['20201002021618.0Z']]);
 
         $this->assertEquals('Fri Oct 02 2020 02:16:18 GMT+0000', $model->windowsDateTime->toString());
+
+        // Reverse casting
+
+        $model->windowsDateTime = new \DateTime('2020-10-02 02:16:18');
+        $this->assertEquals($model->getRawAttribute('windowsDateTime'), ['20201002021618.0Z']);
     }
 
     public function test_windows_int_datetime_attributes_are_casted()
     {
-        $model = (new ModelCastStub())->setRawAttributes(['windowsIntDateTime' => ['132460789290000000']]);
+        $model = (new ModelCastStub)->setRawAttributes(['windowsIntDateTime' => ['132460789290000000']]);
 
         $this->assertEquals('Fri Oct 02 2020 02:22:09 GMT+0000', $model->windowsIntDateTime->toString());
+
+        // Reverse casting
+
+        $model->windowsIntDateTime = new \DateTime('2020-10-02 02:22:09');
+        $this->assertEquals($model->getRawAttribute('windowsIntDateTime'), ['132460789290000000']);
     }
 }
 


### PR DESCRIPTION
Closes #707 

This PR implements reverse casting that previously did not exist, as discovered by @lukasmu.

This means that attributes on LDAP models can now be set to primitives, such as booleans:

```php
$user = User::findOrFail('...');

$user->msExchHideFromAddressList = true;

// ['TRUE']
var_dump($user->getRawAttribute('msExchHideFromAddressList'));
```

And objects, such as dates:

```php
$user = User::findOrFail('...');

$user->accountExpires = new \DateTime('2020-10-02 02:22:09');

// ['132460789290000000']
var_dump($user->getRawAttribute('accountExpires'));
```