### PR TITLE
Bug 714 - Reverse boolean casts no longer accept LDAP string booleans

### DIFF
--- a/src/Models/Concerns/HasAttributes.php
+++ b/src/Models/Concerns/HasAttributes.php
@@ -578,8 +578,12 @@ trait HasAttributes
     /**
      * Cast the value from a primitive boolean to an LDAP boolean string.
      */
-    protected function fromBoolean(bool $value): string
+    protected function fromBoolean(mixed $value): string
     {
+        if (is_string($value)) {
+            $value = $this->asBoolean($value);
+        }
+
         return $value ? 'TRUE' : 'FALSE';
     }
 

--- a/tests/Unit/Models/ModelAttributeCastTest.php
+++ b/tests/Unit/Models/ModelAttributeCastTest.php
@@ -28,6 +28,10 @@ class ModelAttributeCastTest extends TestCase
         $this->assertTrue($model->booleanAttribute);
         $this->assertEquals($model->getRawAttribute('booleanAttribute'), ['TRUE']);
 
+        $model->booleanAttribute = 'false';
+        $this->assertFalse($model->booleanAttribute);
+        $this->assertEquals($model->getRawAttribute('booleanAttribute'), ['FALSE']);
+
         // Casing differences
 
         $model = (new ModelCastStub)->setRawAttributes(['boolAttribute' => ['true']]);


### PR DESCRIPTION
Closes #714 