### PR TITLE
Flush container on DirectoryFake::tearDown

### DIFF
--- a/src/Testing/DirectoryFake.php
+++ b/src/Testing/DirectoryFake.php
@@ -40,8 +40,9 @@ class DirectoryFake
     {
         foreach (static::$replaced as $name => $connection) {
             Container::getConnection($name)->tearDown();
-            Container::addConnection($connection, $name);
         }
+
+        Container::flush();
 
         static::$replaced = [];
     }

--- a/tests/Unit/Testing/DirectoryFakeTest.php
+++ b/tests/Unit/Testing/DirectoryFakeTest.php
@@ -30,4 +30,17 @@ class DirectoryFakeTest extends TestCase
         $this->assertInstanceOf(ConnectionFake::class, $fake);
         $this->assertInstanceOf(LdapFake::class, $fake->getLdapConnection());
     }
+
+    public function testTearDownFlushesContainer()
+    {
+        Container::addConnection(new Connection);
+
+        DirectoryFake::setup();
+
+        $this->assertCount(1, Container::getConnections());
+
+        DirectoryFake::tearDown();
+
+        $this->assertCount(0, Container::getConnections());
+    }
 }


### PR DESCRIPTION
Closes https://github.com/DirectoryTree/LdapRecord-Laravel/issues/653