### PR TITLE
Add ability to set custom LDAP protocol

### DIFF
--- a/src/Configuration/DomainConfiguration.php
+++ b/src/Configuration/DomainConfiguration.php
@@ -29,6 +29,9 @@ class DomainConfiguration
         // The port to use for connecting to your hosts.
         'port' => LdapInterface::PORT,
 
+        // The protocol to use for connecting to your hosts.
+        'protocol' => null,
+
         // The base distinguished name of your domain.
         'base_dn' => '',
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -135,7 +135,11 @@ class Connection
     {
         $this->configure();
 
-        $this->ldap->connect($this->host, $this->configuration->get('port'));
+        $this->ldap->connect(
+            $this->host,
+            $this->configuration->get('port'),
+            $this->configuration->get('protocol')
+        );
     }
 
     /**

--- a/src/HandlesConnection.php
+++ b/src/HandlesConnection.php
@@ -16,6 +16,11 @@ trait HandlesConnection
     protected ?string $host = null;
 
     /**
+     * The LDAP protocol to use.
+     */
+    protected ?string $protocol = null;
+
+    /**
      * The LDAP connection resource.
      *
      * @var Connection
@@ -141,7 +146,11 @@ trait HandlesConnection
      */
     public function getProtocol(): string
     {
-        return $this->isUsingSSL() ? LdapInterface::PROTOCOL_SSL : LdapInterface::PROTOCOL;
+        return $this->protocol ?: (
+            $this->isUsingSSL()
+                ? LdapInterface::PROTOCOL_SSL
+                : LdapInterface::PROTOCOL
+        );
     }
 
     /**

--- a/src/Ldap.php
+++ b/src/Ldap.php
@@ -158,10 +158,10 @@ class Ldap implements LdapInterface
     /**
      * {@inheritdoc}
      */
-    public function connect(string|array $hosts = [], int $port = 389): bool
+    public function connect(string|array $hosts = [], int $port = 389, ?string $protocol = null): bool
     {
         $this->bound = false;
-
+        $this->protocol = $protocol;
         $this->host = $this->makeConnectionUris($hosts, $port);
 
         $this->connection = $this->executeFailableOperation(function () {
@@ -182,9 +182,10 @@ class Ldap implements LdapInterface
             $result = @ldap_close($this->connection);
         }
 
-        $this->connection = null;
         $this->bound = false;
         $this->host = null;
+        $this->protocol = null;
+        $this->connection = null;
 
         return $result;
     }

--- a/src/LdapInterface.php
+++ b/src/LdapInterface.php
@@ -248,7 +248,7 @@ interface LdapInterface
      *
      * @see http://php.net/manual/en/function.ldap-start-tls.php
      */
-    public function connect(string|array $hosts = [], int $port = 389): bool;
+    public function connect(string|array $hosts = [], int $port = 389, ?string $protocol = null): bool;
 
     /**
      * Closes the current connection.

--- a/src/Testing/LdapFake.php
+++ b/src/Testing/LdapFake.php
@@ -336,10 +336,10 @@ class LdapFake implements LdapInterface
     /**
      * {@inheritdoc}
      */
-    public function connect(string|array $hosts = [], int $port = 389): bool
+    public function connect(string|array $hosts = [], int $port = 389, ?string $protocol = null): bool
     {
         $this->bound = false;
-
+        $this->protocol = $protocol;
         $this->host = $this->makeConnectionUris($hosts, $port);
 
         return $this->connection = $this->hasExpectations(__FUNCTION__)
@@ -352,9 +352,10 @@ class LdapFake implements LdapInterface
      */
     public function close(): bool
     {
-        $this->connection = null;
         $this->bound = false;
         $this->host = null;
+        $this->protocol = null;
+        $this->connection = null;
 
         return $this->hasExpectations(__FUNCTION__)
             ? $this->resolveExpectation(__FUNCTION__)

--- a/tests/Unit/Configuration/DomainConfigurationTest.php
+++ b/tests/Unit/Configuration/DomainConfigurationTest.php
@@ -36,6 +36,7 @@ class DomainConfigurationTest extends TestCase
         $config = new DomainConfiguration();
 
         $this->assertEquals(389, $config->get('port'));
+        $this->assertNull($config->get('protocol'));
         $this->assertEmpty($config->get('hosts'));
         $this->assertEquals(0, $config->get('follow_referrals'));
         $this->assertEmpty($config->get('username'));
@@ -50,6 +51,7 @@ class DomainConfigurationTest extends TestCase
     {
         $config = new DomainConfiguration([
             'port' => 500,
+            'protocol' => 'foo://',
             'base_dn' => 'dc=corp,dc=org',
             'hosts' => ['dc1', 'dc2'],
             'follow_referrals' => false,
@@ -67,6 +69,7 @@ class DomainConfigurationTest extends TestCase
         ]);
 
         $this->assertEquals(500, $config->get('port'));
+        $this->assertEquals('foo://', $config->get('protocol'));
         $this->assertEquals('dc=corp,dc=org', $config->get('base_dn'));
         $this->assertEquals(['dc1', 'dc2'], $config->get('hosts'));
         $this->assertEquals('username', $config->get('username'));
@@ -92,6 +95,7 @@ class DomainConfigurationTest extends TestCase
             'timeout' => 5,
             'version' => 3,
             'port' => 389,
+            'protocol' => null,
             'base_dn' => '',
             'username' => '',
             'password' => '',

--- a/tests/Unit/FakeDirectoryTest.php
+++ b/tests/Unit/FakeDirectoryTest.php
@@ -50,6 +50,7 @@ class FakeDirectoryTest extends TestCase
             'username' => 'user',
             'password' => 'pass',
             'port' => 389,
+            'protocol' => null,
             'use_tls' => true,
             'use_ssl' => false,
             'use_sasl' => false,

--- a/tests/Unit/LdapTest.php
+++ b/tests/Unit/LdapTest.php
@@ -3,6 +3,7 @@
 namespace LdapRecord\Tests\Unit;
 
 use LdapRecord\Ldap;
+use LdapRecord\LdapInterface;
 use LdapRecord\Testing\LdapFake;
 use LdapRecord\Tests\TestCase;
 use Mockery as m;
@@ -12,11 +13,11 @@ class LdapTest extends TestCase
     public function test_construct_defaults()
     {
         $ldap = new Ldap();
-
         $this->assertFalse($ldap->isUsingTLS());
         $this->assertFalse($ldap->isUsingSSL());
         $this->assertFalse($ldap->isBound());
         $this->assertNull($ldap->getConnection());
+        $this->assertEquals($ldap->getProtocol(), LdapInterface::PROTOCOL);
     }
 
     public function test_host_arrays_are_properly_processed()
@@ -28,13 +29,13 @@ class LdapTest extends TestCase
         $this->assertEquals('ldap://dc01:500 ldap://dc02:500', $ldap->getHost());
     }
 
-    public function test_host_strings_are_properly_processed()
+    public function test_host_strings_are_properly_created()
     {
         $ldap = new LdapFake();
 
-        $ldap->connect('dc01', $port = 500);
+        $ldap->connect('dc01', $port = 500, 'foo://');
 
-        $this->assertEquals('ldap://dc01:500', $ldap->getHost());
+        $this->assertEquals('foo://dc01:500', $ldap->getHost());
     }
 
     public function test_get_default_protocol()


### PR DESCRIPTION
Closes #732

This PR adds the ability to set a set a custom protocol on LDAP connections in case developers need this control.