### PR TITLE
Bug 761 - Properly override query limit to `0` when chunking

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -428,6 +428,8 @@ class Builder
      */
     public function chunk(int $pageSize, Closure $callback, bool $isCritical = false, bool $isolate = false): bool
     {
+        $this->limit(0);
+
         $start = microtime(true);
 
         $chunk = function (Builder $query) use ($pageSize, $callback, $isCritical) {

--- a/tests/Integration/QueryTest.php
+++ b/tests/Integration/QueryTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace LdapRecord\Tests\Integration;
+
+use Illuminate\Support\LazyCollection;
+use LdapRecord\Models\OpenLDAP\User;
+use LdapRecord\Query\Collection;
+use LdapRecord\Tests\Integration\Concerns\MakesUsers;
+use LdapRecord\Tests\Integration\Concerns\SetupTestConnection;
+use LdapRecord\Tests\Integration\Concerns\SetupTestOu;
+
+class QueryTest extends TestCase
+{
+    use MakesUsers;
+    use SetupTestConnection;
+    use SetupTestOu;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setupTestOu();
+    }
+
+    public function test_it_can_paginate()
+    {
+        foreach (LazyCollection::range(1, 10) as $index) {
+            $this->makeUser($this->ou)->save();
+        }
+
+        $this->assertCount(10, User::paginate(5));
+    }
+
+    public function test_it_can_chunk()
+    {
+        foreach (LazyCollection::range(1, 10) as $index) {
+            $this->makeUser($this->ou)->save();
+        }
+
+        $pages = 0;
+
+        User::chunk(5, function (Collection $results) use (&$pages) {
+            $pages++;
+
+            $this->assertCount(5, $results);
+        });
+
+        $this->assertEquals(2, $pages);
+    }
+
+    public function test_it_cannot_override_limit_when_chunking()
+    {
+        foreach (LazyCollection::range(1, 10) as $index) {
+            $this->makeUser($this->ou)->save();
+        }
+
+        $pages = 0;
+
+        User::limit(1)->chunk(5, function (Collection $results) use (&$pages) {
+            $pages++;
+
+            $this->assertCount(5, $results);
+        });
+
+        $this->assertEquals(2, $pages);
+    }
+}


### PR DESCRIPTION
Closes #761 