### PR TITLE
Bug 779 - Rounding error when retrieving timestamp from Active Directory

### DIFF
--- a/src/Models/Attributes/Timestamp.php
+++ b/src/Models/Attributes/Timestamp.php
@@ -190,7 +190,7 @@ class Timestamp
         }
 
         return (new DateTime)->setTimestamp(
-            round($value / 10000000) - 11644473600
+            (int) ($value / 10000000) - 11644473600
         );
     }
 

--- a/tests/Unit/Models/Attributes/TimestampTest.php
+++ b/tests/Unit/Models/Attributes/TimestampTest.php
@@ -146,4 +146,17 @@ class TimestampTest extends TestCase
         $this->assertSame($min, $timestamp->toDateTime($min));
         $this->assertSame($min, $timestamp->toDateTime((string) $min));
     }
+
+    public function test_windows_int_type_rounds_correctly()
+    {
+        $timestamp = new Timestamp('windows-int');
+
+        foreach (['133692539995000000', '133692539999500000'] as $windowsIntegerTime) {
+            $dateTime = $timestamp->toDateTime($windowsIntegerTime);
+
+            $expectedUnixTimestamp = (int) ($windowsIntegerTime / 10000000) - 11644473600;
+
+            $this->assertEquals($expectedUnixTimestamp, $dateTime->getTimestamp());
+        }
+    }
 }


### PR DESCRIPTION
Closes #779 