### PR TITLE
Fix date attributes producing invalid UNIX timestamps on 32-bit PHP

### DIFF
--- a/src/Models/Attributes/Timestamp.php
+++ b/src/Models/Attributes/Timestamp.php
@@ -190,7 +190,7 @@ class Timestamp
         }
 
         return (new DateTime)->setTimestamp(
-            (int) ($value / 10000000) - 11644473600
+            (int) (round($value / 10000000) - 11644473600)
         );
     }
 

--- a/tests/Unit/Models/Attributes/TimestampTest.php
+++ b/tests/Unit/Models/Attributes/TimestampTest.php
@@ -154,7 +154,7 @@ class TimestampTest extends TestCase
         foreach (['133692539995000000', '133692539999500000'] as $windowsIntegerTime) {
             $dateTime = $timestamp->toDateTime($windowsIntegerTime);
 
-            $expectedUnixTimestamp = (int) ($windowsIntegerTime / 10000000) - 11644473600;
+            $expectedUnixTimestamp = (int) (round($windowsIntegerTime / 10000000) - 11644473600);
 
             $this->assertEquals($expectedUnixTimestamp, $dateTime->getTimestamp());
         }


### PR DESCRIPTION
Closes #801 

This PR implements using `round()` when converting Windows integer timestamps to UNIX timestamps, ensuring an int is always passed to `DateTime::setTimestamp()`. Without this, 32-bit PHP produces a float, causing a TypeError (as mentioned in the bug report).

