### PR TITLE
Fix global scope query mutations

### DIFF
--- a/src/Query/Model/Builder.php
+++ b/src/Query/Model/Builder.php
@@ -499,12 +499,10 @@ class Builder
             }
 
             $builder->callScope(function (self $builder) use ($scope) {
-                if ($scope instanceof Closure) {
-                    $scope($builder);
-                }
-
                 if ($scope instanceof Scope) {
                     $scope->apply($builder, $this->getModel());
+                } else {
+                    $scope($builder);
                 }
             });
 

--- a/src/Query/Model/Builder.php
+++ b/src/Query/Model/Builder.php
@@ -133,7 +133,17 @@ class Builder
     {
         array_unshift($parameters, $this);
 
-        return $scope(...array_values($parameters)) ?? $this;
+        $result = null;
+
+        $scopeFilter = $this->captureScopeFilters(function () use ($scope, $parameters, &$result) {
+            $result = $scope(...$parameters) ?? $this;
+        });
+
+        if ($scopeFilter) {
+            $this->query->addFilter($scopeFilter);
+        }
+
+        return $result;
     }
 
     /**
@@ -477,25 +487,49 @@ class Builder
             return $this;
         }
 
-        // Scopes should not be escapable, so we will wrap the
-        // application of the scopes within a nested query.
-        $this->where(function (self $query) {
-            foreach ($this->scopes as $identifier => $scope) {
-                if (isset($this->appliedScopes[$identifier])) {
-                    continue;
+        $builder = clone $this;
+
+        foreach ($this->scopes as $identifier => $scope) {
+            if (! isset($builder->scopes[$identifier])) {
+                continue;
+            }
+
+            if (isset($builder->appliedScopes[$identifier])) {
+                continue;
+            }
+
+            $builder->callScope(function (self $builder) use ($scope) {
+                if ($scope instanceof Closure) {
+                    $scope($builder);
                 }
 
                 if ($scope instanceof Scope) {
-                    $scope->apply($query, $this->getModel());
-                } else {
-                    $scope($this);
+                    $scope->apply($builder, $this->getModel());
                 }
+            });
 
-                $this->appliedScopes[$identifier] = $scope;
-            }
-        });
+            $builder->appliedScopes[$identifier] = $scope;
+        }
 
-        return $this;
+        return $builder;
+    }
+
+    /**
+     * Capture the filters applied while executing the callback.
+     */
+    protected function captureScopeFilters(Closure $callback): ?Filter
+    {
+        $originalFilter = $this->query->filter;
+
+        $this->query->filter = null;
+
+        try {
+            $callback();
+
+            return $this->query->filter;
+        } finally {
+            $this->query->filter = $originalFilter;
+        }
     }
 
     /**

--- a/tests/Unit/Models/ActiveDirectory/ExchangeDatabaseTest.php
+++ b/tests/Unit/Models/ActiveDirectory/ExchangeDatabaseTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace LdapRecord\Tests\Unit\Models\ActiveDirectory;
+
+use LdapRecord\Connection;
+use LdapRecord\Container;
+use LdapRecord\Models\ActiveDirectory\ExchangeDatabase;
+use LdapRecord\Testing\DirectoryFake;
+use LdapRecord\Testing\LdapFake;
+use LdapRecord\Tests\TestCase;
+
+class ExchangeDatabaseTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Container::addConnection(new Connection);
+
+        ExchangeDatabase::clearBootedModels();
+    }
+
+    protected function tearDown(): void
+    {
+        DirectoryFake::tearDown();
+
+        parent::tearDown();
+    }
+
+    public function test_configuration_context_scope_sets_the_query_base_dn()
+    {
+        DirectoryFake::setup()->getLdapConnection()->expect(
+            LdapFake::operation('read')->once()->andReturn([
+                [
+                    'dn' => '',
+                    'configurationNamingContext' => ['CN=Configuration,DC=local,DC=com'],
+                ],
+            ])
+        );
+
+        $this->assertSame(
+            'CN=Configuration,DC=local,DC=com',
+            ExchangeDatabase::query()->toBase()->getDn()
+        );
+    }
+}

--- a/tests/Unit/Models/ModelScopeTest.php
+++ b/tests/Unit/Models/ModelScopeTest.php
@@ -83,7 +83,7 @@ class ModelScopeTest extends TestCase
         $query->toBase();
         $query->toBase();
 
-        $this->assertEquals('(&(foo=bar))', $query->toBase()->getQuery());
+        $this->assertEquals('(foo=bar)', $query->toBase()->getQuery());
     }
 
     public function test_local_scopes_can_be_called()
@@ -138,11 +138,11 @@ class ModelScopeTest extends TestCase
 
     public function test_scopes_cannot_be_negated_by_or_clauses()
     {
-        // The scope should be wrapped in its own AND group, so the OR clause
-        // cannot negate it. The filter should be: (&(bypass=...)(&(foo=bar)))
-        // NOT: (|(foo=bar)(bypass=...)) which would allow bypassing the scope
+        // The scope should be composed onto the query using AND, so the OR clause
+        // cannot negate it. The filter should be: (&(bypass=...)(foo=bar))
+        // NOT: (|(foo=bar)(bypass=...)) which would allow bypassing the scope.
         $this->assertEquals(
-            '(&(bypass=\61\74\74\65\6d\70\74)(&(foo=bar)))',
+            '(&(bypass=\61\74\74\65\6d\70\74)(foo=bar))',
             ModelWithGlobalScopeTestStub::query()
                 ->orWhere('bypass', '=', 'attempt')
                 ->toBase()
@@ -154,7 +154,7 @@ class ModelScopeTest extends TestCase
     {
         // Scope must remain enforced regardless of OR clauses
         $this->assertEquals(
-            '(&(|(bypass1=\61\74\74\65\6d\70\74\31)(bypass2=\61\74\74\65\6d\70\74\32))(&(foo=bar)))',
+            '(&(|(bypass1=\61\74\74\65\6d\70\74\31)(bypass2=\61\74\74\65\6d\70\74\32))(foo=bar))',
             ModelWithGlobalScopeTestStub::query()
                 ->orWhere('bypass1', '=', 'attempt1')
                 ->orWhere('bypass2', '=', 'attempt2')
@@ -167,7 +167,7 @@ class ModelScopeTest extends TestCase
     {
         // The scope (foo=bar) must always be present and enforced at the root AND level
         $this->assertEquals(
-            '(&(&(|(name=\4a\6f\68\6e)(name=\4a\61\6e\65))(active=\74\72\75\65))(&(foo=bar)))',
+            '(&(|(name=\4a\6f\68\6e)(name=\4a\61\6e\65))(active=\74\72\75\65)(foo=bar))',
             ModelWithGlobalScopeTestStub::query()
                 ->where('name', '=', 'John')
                 ->orWhere('name', '=', 'Jane')

--- a/tests/Unit/Query/Model/BuilderScopeTest.php
+++ b/tests/Unit/Query/Model/BuilderScopeTest.php
@@ -18,11 +18,16 @@ class BuilderScopeTest extends TestCase
     {
         $b = new Builder(new Entry, new QueryBuilder(new Connection));
 
-        $b->withGlobalScope('foo', function ($query) use ($b) {
-            $this->assertSame($b, $query);
+        $scoped = null;
+
+        $b->withGlobalScope('foo', function ($query) use (&$scoped) {
+            $scoped = $query;
         });
 
-        $b->applyScopes();
+        $applied = $b->applyScopes();
+
+        $this->assertNotSame($b, $applied);
+        $this->assertSame($applied, $scoped);
     }
 
     public function test_class_scopes_can_be_applied()
@@ -33,11 +38,54 @@ class BuilderScopeTest extends TestCase
 
         $b->withGlobalScope('foo', new TestModelScope);
 
-        // Scopes are wrapped in an AndGroup to prevent negation
-        $this->assertEquals('(&(foo=LdapRecord\Models\Entry))', $b->getUnescapedQuery());
+        // Scope filters are composed onto the scoped query builder.
+        $scoped = $b->applyScopes();
 
-        $this->assertCount(1, $b->appliedScopes());
-        $this->assertArrayHasKey('foo', $b->appliedScopes());
+        $this->assertEquals('(foo=LdapRecord\Models\Entry)', $scoped->getUnescapedQuery());
+
+        $this->assertEmpty($b->appliedScopes());
+        $this->assertCount(1, $scoped->appliedScopes());
+        $this->assertArrayHasKey('foo', $scoped->appliedScopes());
+    }
+
+    public function test_scope_or_filters_are_preserved_when_grouped()
+    {
+        $b = new Builder(new Entry, new QueryBuilder(new Connection));
+
+        $b->where('cn', '=', 'John Doe');
+
+        $b->withGlobalScope('foo', function ($query) {
+            $query->orWhere('foo', '=', 'bar');
+            $query->orWhere('bar', '=', 'baz');
+        });
+
+        $this->assertEquals(
+            '(&(cn=John Doe)(|(foo=bar)(bar=baz)))',
+            $b->toBase()->getUnescapedQuery()
+        );
+    }
+
+    public function test_complex_scope_filters_cannot_be_negated_by_complex_queries()
+    {
+        $b = new Builder(new Entry, new QueryBuilder(new Connection));
+
+        $b->where('department', '=', 'Sales')
+            ->orWhere('department', '=', 'Support')
+            ->where('enabled', '=', 'true');
+
+        $b->withGlobalScope('foo', function ($query) {
+            $query->orFilter(function ($query) {
+                $query->where('type', '=', 'person');
+                $query->where('type', '=', 'contact');
+            });
+
+            $query->where('tenant', '=', 'acme');
+        });
+
+        $this->assertEquals(
+            '(&(|(department=Sales)(department=Support))(enabled=true)(&(|(type=person)(type=contact))(tenant=acme)))',
+            $b->toBase()->getUnescapedQuery()
+        );
     }
 
     public function test_scopes_can_be_removed_after_being_added()


### PR DESCRIPTION
Closes #802

This PR updates global scope application to more closely match Eloquent by applying scopes to a cloned builder, allowing scope mutations like `in()` / `setDn()` to affect the scoped query.

This also preserves scope filter composition so developer `orWhere()` clauses cannot negate global scopes, and adds regression coverage for `InConfigurationContext` and complex scope filtering.